### PR TITLE
Add full Korean Bible (KRV) support with clean verse parsing and cross-book navigation

### DIFF
--- a/src/pages/Study/Bible.js
+++ b/src/pages/Study/Bible.js
@@ -4,184 +4,202 @@ import GetBookVersions from "./bookVersions/GetBookVersions";
 import BibleVersion from "./bibleVersions/BibleVersions";
 import Verse from "./verseDisplay/Verse";
 
-// KOR chapter counts keyed by ibibles-style codes
+// Static chapter counts for Korean ibibles.net mapping
 const KOR_CHAPTER_COUNTS = {
-  gen: 50,
+  ge: 50,
   exo: 40,
   lev: 27,
   num: 36,
   deu: 34,
-  jos: 24,
-  jdg: 21,
-  rut: 4,
-  "1sa": 31,
-  "2sa": 24,
+  josh: 24,
+  jdgs: 21,
+  ruth: 4,
+  "1sm": 31,
+  "2sm": 24,
   "1ki": 22,
   "2ki": 25,
-  "1ch": 29,
-  "2ch": 36,
-  ezr: 10,
+  "1chr": 29,
+  "2chr": 36,
+  ezra: 10,
   neh: 13,
   est: 10,
   job: 42,
   psa: 150,
-  pro: 31,
-  ecc: 12,
-  sng: 8,
+  prv: 31,
+  eccl: 12,
+  ssol: 8,
   isa: 66,
   jer: 52,
   lam: 5,
   eze: 48,
   dan: 12,
   hos: 14,
-  joe: 3,
-  amo: 9,
-  oba: 1,
-  jon: 4,
+  joel: 3,
+  amos: 9,
+  obad: 1,
+  jonah: 4,
   mic: 7,
-  nah: 3,
+  nahum: 3,
   hab: 3,
   zep: 3,
   hag: 2,
   zec: 14,
   mal: 4,
   mat: 28,
-  mrk: 16,
-  luk: 24,
-  jhn: 21,
-  act: 28,
+  mark: 16,
+  luke: 24,
+  john: 21,
+  acts: 28,
   rom: 16,
-  "1co": 16,
-  "2co": 13,
+  "1cor": 16,
+  "2cor": 13,
   gal: 6,
   eph: 6,
-  php: 4,
+  phi: 4,
   col: 4,
   "1th": 5,
   "2th": 3,
-  "1ti": 6,
-  "2ti": 4,
-  tit: 3,
-  phm: 1,
+  "1tim": 6,
+  "2tim": 4,
+  titus: 3,
+  phmn: 1,
   heb: 13,
   jas: 5,
-  "1pe": 5,
-  "2pe": 3,
+  "1pet": 5,
+  "2pet": 3,
   "1jn": 5,
   "2jn": 1,
   "3jn": 1,
-  jud: 1,
+  jude: 1,
   rev: 22,
 };
 
 const Bible = () => {
-  const [currVersionId, setCurrVersionId] = useState("06125adad2d5898a-01"); // ASV
+  const [currChapterId, setCurrentChapterId] = useState(null); // e.g. "gen.1"
   const [currBook, setCurrBook] = useState({ id: null, name: "" });
-  const [currChapterId, setCurrChapterId] = useState(null); // e.g. "GEN.1" or "gen.1"
+  const [currVersion, setCurrVersion] = useState("06125adad2d5898a-01"); // default ASV
 
-  const [booksOrder, setBooksOrder] = useState([]);          // [{ id, name }]
-  const [chaptersByBook, setChaptersByBook] = useState({});  // { [bookId]: [{id, number}] }
+  // Ordered list of books for current version: [{ id, name }]
+  const [booksOrder, setBooksOrder] = useState([]);
 
-  // 1) Load books list whenever version changes
+  // Cache of chapters per book: { [bookId]: [{ id, number }] }
+  const [chaptersByBook, setChaptersByBook] = useState({});
+
+  // ---- Load books when version changes ----
   useEffect(() => {
     let cancelled = false;
 
     (async () => {
       try {
-        const books = await GetBookVersions(currVersionId);
+        const books = await GetBookVersions(currVersion); // returns KOR_BOOKS for "kor"
         if (!cancelled) {
           setBooksOrder(books || []);
         }
-      } catch (err) {
-        console.error("Failed to load books for version", currVersionId, err);
-        if (!cancelled) setBooksOrder([]);
+      } catch (e) {
+        if (!cancelled) {
+          console.error("Failed to load books for version", currVersion, e);
+          setBooksOrder([]);
+        }
       }
     })();
 
-    // reset selection when version changes
-    setCurrBook({ id: null, name: "" });
-    setCurrChapterId(null);
+    // clear chapter cache when version changes
     setChaptersByBook({});
+    setCurrBook({ id: null, name: "" });
+    setCurrentChapterId(null);
 
     return () => {
       cancelled = true;
     };
-  }, [currVersionId]);
+  }, [currVersion]);
 
-  // 2) Fetch chapters for a given book (memoized to avoid infinite loops)
+  // ---- Helper: fetch/load chapters for a given book ----
   const fetchChapters = useCallback(
     async (bookId) => {
       if (!bookId) return [];
 
-      // if we already have chapters cached, just return them
+      // If we already have them cached, reuse
       if (chaptersByBook[bookId]) {
         return chaptersByBook[bookId];
       }
 
-      // KOR: generate from static counts
-      if (currVersionId === "kor") {
+      // KOREAN: use static chapter counts
+      if (currVersion === "kor") {
         const count = KOR_CHAPTER_COUNTS[bookId] || 0;
         const list = Array.from({ length: count }, (_, i) => ({
           number: i + 1,
           id: `${bookId}.${i + 1}`,
         }));
-        setChaptersByBook((prev) => ({ ...prev, [bookId]: list }));
+
+        setChaptersByBook((prev) => ({
+          ...prev,
+          [bookId]: list,
+        }));
+
         return list;
       }
 
-      // Other versions: hit api.bible
+      // Other versions: use api.scripture.api.bible
+      const url = `https://api.scripture.api.bible/v1/bibles/${currVersion}/books/${bookId}/chapters`;
+
       try {
-        const res = await fetch(
-          `https://api.scripture.api.bible/v1/bibles/${currVersionId}/books/${bookId}/chapters`,
-          { headers: { "api-key": API } }
-        );
-        if (!res.ok) {
-          console.error("Chapters fetch failed", res.status, bookId);
-          return [];
-        }
+        const res = await fetch(url, {
+          headers: { "api-key": API, accept: "application/json" },
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
         const { data } = await res.json();
-        const list = (data || []).map(({ id, number }) => ({ id, number }));
-        setChaptersByBook((prev) => ({ ...prev, [bookId]: list }));
-        return list;
-      } catch (err) {
-        console.error("Chapters fetch error", err);
+        const arr = (data || []).map(({ id, number }) => ({
+          id,
+          number,
+        }));
+
+        setChaptersByBook((prev) => ({
+          ...prev,
+          [bookId]: arr,
+        }));
+
+        return arr;
+      } catch (e) {
+        console.error("Failed to load chapters", { bookId, currVersion }, e);
         return [];
       }
     },
-    [currVersionId, chaptersByBook]
+    [currVersion, chaptersByBook]
   );
 
-  // 3) When current book changes, ensure its chapters are loaded once
+  // Ensure current book's chapters are loaded when book changes
   useEffect(() => {
     if (currBook?.id) {
       fetchChapters(currBook.id);
     }
   }, [currBook?.id, fetchChapters]);
 
-  // 4) Helpers for current chapter + book indices
-  const currChapters = useMemo(
-    () => (currBook?.id ? chaptersByBook[currBook.id] || [] : []),
-    [chaptersByBook, currBook?.id]
-  );
+  // Current book's chapter list
+  const currChapters = useMemo(() => {
+    if (!currBook?.id) return [];
+    return chaptersByBook[currBook.id] || [];
+  }, [chaptersByBook, currBook?.id]);
 
-  const currChapterIndex = useMemo(
-    () => currChapters.findIndex((c) => c.id === currChapterId),
-    [currChapters, currChapterId]
-  );
+  // Index of current chapter in that list
+  const currChapterIndex = useMemo(() => {
+    if (!currChapterId || !currChapters.length) return -1;
+    return currChapters.findIndex((c) => c.id === currChapterId);
+  }, [currChapters, currChapterId]);
 
+  // Find book index in booksOrder
   const getBookIndex = useCallback(
     (bookId) => booksOrder.findIndex((b) => b.id === bookId),
     [booksOrder]
   );
 
-  // 5) Navigation helpers
+  // Jump helpers
   const goToFirstChapterOf = useCallback(
     async (bookObj) => {
-      if (!bookObj) return;
       const list = await fetchChapters(bookObj.id);
       if (list.length) {
         setCurrBook(bookObj);
-        setCurrChapterId(list[0].id);
+        setCurrentChapterId(list[0].id);
       }
     },
     [fetchChapters]
@@ -189,34 +207,35 @@ const Bible = () => {
 
   const goToLastChapterOf = useCallback(
     async (bookObj) => {
-      if (!bookObj) return;
       const list = await fetchChapters(bookObj.id);
       if (list.length) {
         setCurrBook(bookObj);
-        setCurrChapterId(list[list.length - 1].id);
+        setCurrentChapterId(list[list.length - 1].id);
       }
     },
     [fetchChapters]
   );
 
+  // ---- Navigation: Next chapter / book ----
   const goNextChapter = useCallback(async () => {
     if (!currBook?.id) return;
 
-    // within same book
+    // 1) Next chapter in same book
     if (
       currChapterIndex >= 0 &&
       currChapterIndex < currChapters.length - 1
     ) {
-      setCurrChapterId(currChapters[currChapterIndex + 1].id);
+      setCurrentChapterId(currChapters[currChapterIndex + 1].id);
       return;
     }
 
-    // go to first chapter of next book
+    // 2) We're at last chapter of this book → go to first chapter of next book
     const bi = getBookIndex(currBook.id);
     if (bi >= 0 && bi < booksOrder.length - 1) {
       const nextBook = booksOrder[bi + 1];
       await goToFirstChapterOf(nextBook);
     }
+    // If bi is last index or -1 → no next book → do nothing
   }, [
     currBook,
     currChapters,
@@ -226,21 +245,23 @@ const Bible = () => {
     goToFirstChapterOf,
   ]);
 
+  // ---- Navigation: Previous chapter / book ----
   const goPrevChapter = useCallback(async () => {
     if (!currBook?.id) return;
 
-    // within same book
+    // 1) Previous chapter in same book
     if (currChapterIndex > 0) {
-      setCurrChapterId(currChapters[currChapterIndex - 1].id);
+      setCurrentChapterId(currChapters[currChapterIndex - 1].id);
       return;
     }
 
-    // go to last chapter of previous book
+    // 2) We're at first chapter → go to last chapter of previous book
     const bi = getBookIndex(currBook.id);
     if (bi > 0) {
       const prevBook = booksOrder[bi - 1];
       await goToLastChapterOf(prevBook);
     }
+    // If bi <= 0 → no previous book
   }, [
     currBook,
     currChapters,
@@ -250,40 +271,54 @@ const Bible = () => {
     goToLastChapterOf,
   ]);
 
-  // 6) Arrow visibility
-  const canPrev =
-    !!currBook?.id &&
-    ((currChapterIndex > 0) || getBookIndex(currBook.id) > 0);
+  // ---- Arrow visibility ----
+  const canPrev = useMemo(() => {
+    if (!currBook?.id) return false;
+    const bi = getBookIndex(currBook.id);
+    return currChapterIndex > 0 || bi > 0;
+  }, [currBook?.id, currChapterIndex, getBookIndex]);
 
-  const canNext =
-    !!currBook?.id &&
-    (
+  const canNext = useMemo(() => {
+    if (!currBook?.id) return false;
+    const bi = getBookIndex(currBook.id);
+    return (
       (currChapterIndex >= 0 &&
         currChapterIndex < currChapters.length - 1) ||
-      getBookIndex(currBook.id) < booksOrder.length - 1
+      bi < booksOrder.length - 1
     );
+  }, [
+    currBook?.id,
+    currChapterIndex,
+    currChapters.length,
+    getBookIndex,
+    booksOrder.length,
+  ]);
 
-  // 7) Render
   return (
     <section className="ReadBible">
       <BibleVersion
-        setChapter={setCurrChapterId}
+        setChapter={setCurrentChapterId}
         book={currBook}
         setBook={(b) => {
-          // b is {id, name} from modal, or null when cleared
-          setCurrBook(b || { id: null, name: "" });
-          setCurrChapterId(null);
+          // selecting a new book from modal
+          if (!b) {
+            setCurrBook({ id: null, name: "" });
+            setCurrentChapterId(null);
+            return;
+          }
+          setCurrBook(b);
+          setCurrentChapterId(null); // wait for chapter selection
         }}
-        currVersionId={currVersionId}
+        currVersionId={currVersion}
         setCurrentVersion={(v) => {
-          setCurrVersionId(v);
-          // the effect on currVersionId will handle clearing state
+          setCurrVersion(v);
+          // booksOrder + chaptersByBook are reset in the useEffect above
         }}
       />
 
       <Verse
         chapterId={currChapterId}
-        currVersionId={currVersionId}
+        currVersionId={currVersion}
         book={currBook}
         onPrev={goPrevChapter}
         onNext={goNextChapter}

--- a/src/pages/Study/verseDisplay/Verse.css
+++ b/src/pages/Study/verseDisplay/Verse.css
@@ -1,73 +1,70 @@
 :root {
-  --content-width: 680px;     
-  --arrow-offset: 56px;      
-  --arrow-size: 44px;         
+  --content-width: 680px;
+  --arrow-offset: 56px;
+  --arrow-size: 44px;
 }
 
 .DisplaySection {
-    width: 680px;
-    padding-top: 30px;
-    margin: 0 auto;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  width: 680px;
+  padding-top: 30px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .bookChapterHeader {
-    width: 100%;
-    text-align: center;
+  width: 100%;
+  text-align: center;
 }
 
 .displayArea {
-    padding-top: 30px;
-    width: 80%;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
+  padding-top: 30px;
+  width: 80%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .versesList {
   list-style: none;
-  counter-reset: verse;
   padding-left: 0;
   padding-bottom: 200px;
+  margin: 0;
 }
 
-/* verse padding -- subjected to change */
-.versesList li {
-  position: relative;
-  padding-left: 0.5rem;
-  padding-bottom: 10px;
-  counter-increment: verse;
+/* Each row = up to 2 verses */
+.verseRowPair {
+  padding-bottom: 12px;
 }
 
-.versesList li::before {
-  content: counter(verse);
-  position: absolute;
-  left: 0;
-  top: -0.1em;  /* now this works */
-  font-size: 0.5rem;
+/* Container for each single verse inside the pair */
+.verseChunk {
+  display: inline;          /* seamless flow */
+  margin-right: 10px;       /* small gap between verse pairs */
+}
+
+/* Visual for the numbers we render in JSX */
+.verseNum {
+  font-size: 0.65rem;
+  vertical-align: top;
+  margin-right: 3px;
   color: #888;
   font-weight: 600;
 }
 
-.verseNumber {
-    font-size: 0.8em;
-    color: #4a90e2;
-    margin-right: 6px;
-    font-weight: bold;
+.versesList li::before {
+  content: none;
 }
 
-.verseText {
-    flex: 1;
-    color: #222;
-}
+
 
 .navArrow {
   position: fixed;
   top: 70%;
   transform: translateY(-50%);
-  z-index: 800;              /* above page content, below modals if those use >1000 */
+  z-index: 800;
+  /* above page content, below modals if those use >1000 */
   width: var(--arrow-size);
   height: var(--arrow-size);
   display: inline-flex;
@@ -75,8 +72,8 @@
   justify-content: center;
   border: none;
   border-radius: 999px;
-  background: rgba(0,0,0,0.08);
-  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+  background: rgba(0, 0, 0, 0.08);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   cursor: pointer;
   font-size: 1.25rem;
   line-height: 1;
@@ -84,8 +81,13 @@
   transition: background 0.2s, transform 0.1s;
 }
 
-.navArrow:hover { background: rgba(0,0,0,0.12); }
-.navArrow:active { transform: translateY(-50%) scale(0.98); }
+.navArrow:hover {
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.navArrow:active {
+  transform: translateY(-50%) scale(0.98);
+}
 
 /* Place them near the content column. The content is centered, so its left edge is (50% - content/2) */
 .navArrowLeft {
@@ -99,13 +101,20 @@
 
 /* Hide arrows entirely when they’re not renderable (you already conditionally render them).
    If you ever keep them mounted, you can also visually hide with: */
-.navArrow[disabled] { display: none; }
+.navArrow[disabled] {
+  display: none;
+}
 
 /* Small screens: bring arrows closer to edges and make them slightly smaller */
 @media (max-width: 768px) {
   :root {
-    --content-width: 100vw;   /* content effectively full width on mobile */
+    --content-width: 100vw;
+    /* content effectively full width on mobile */
     --arrow-offset: 12px;
     --arrow-size: 40px;
+  }
+
+  .versesList {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
**Backend (Express)**

Added a new endpoint:
GET /api/passage/:versionId/:chapterId

When versionId === "kor", the server now:
Fetches data from http://ibibles.net/quote.php?kor-{book}/{chapter}:1-200
Parses and sanitizes raw HTML into structured JSON:

{
  "versionId": "kor",
  "chapterId": "josh.7",
  "bookId": "josh",
  "chapter": 7,
  "verses": [
    { "id": "josh.7.1", "number": 1, "text": "..." },
    ...
  ]
}

Removes all embedded “Bible Quote” text and unwanted chapter/verse prefixes (3:1, 3:2, etc.).
Normalizes spacing and prevents duplicated verses.
Added error handling and fallbacks to handle incomplete or malformed ibibles.net data.


**Frontend (React)**
Verse.jsx

1. Integrated backend endpoint /api/passage/kor/:chapterId to fetch Korean text.
2. Cleanly renders verses line-by-line, pairing two per row for consistency.
3. Removes embedded verse markers and prevents duplicate numbers.
4. Unified rendering with other Bible versions for a consistent reading experience.

**Navigation & State Management**
Bible.js

Added KOR_CHAPTER_COUNTS static mapping for accurate chapter data from ibibles.net.
Updated navigation logic:

When reaching the last chapter of a Korean book → jumps automatically to the first chapter of the next book.
When moving backward from the first chapter → jumps to the last chapter of the previous book.
Ensured canNext and canPrev correctly reflect book boundaries.
Confirmed full functionality for both keyboard (←, →) and button navigation.