### PR TITLE
Add Korean Bible support and unified book/chapter navigation

### DIFF
--- a/src/pages/Study/bibleVersions/BibleVersionComponent.js
+++ b/src/pages/Study/bibleVersions/BibleVersionComponent.js
@@ -25,7 +25,7 @@ const BookVersionComponent = (props) => {
       <section className="ModalFilter">
         <input
           className="ModalFilterInput"
-          placeholder="Filter Books..."
+          placeholder="Filter versions..."
           value={filterText}
           onChange={filterChangeHandler}
         />

--- a/src/pages/Study/bibleVersions/IndividualVersion.js
+++ b/src/pages/Study/bibleVersions/IndividualVersion.js
@@ -1,18 +1,19 @@
 import "./IndividualVersion.css";
 
-const IndividualVersion = (props) => {
+const IndividualVersion = ({ version, id, chVer, setId, setVis }) => {
+  const clickHandler = () => {
+    const abbr = version.abbreviation || version.id;
+    if (!abbr || !id) return;
 
-  const clickHandler = () =>{
-    props.chVer(props.version.abbreviation);
-    props.setId(props.id);
-    props.setVis(false);
+    chVer(abbr);     // e.g. "ASV" / "KOR"
+    setId(id);       // e.g. api.bible id / "kor"
+    setVis(false);
   };
 
   return (
-    // <li className="bibleItem" onClick={()=>chVer(version.id)}>
     <li className="bibleItem" onClick={clickHandler}>
       <p>
-        {props.version.abbreviation} - {props.version.name}
+        {version.abbreviation || version.id} - {version.name}
       </p>
     </li>
   );

--- a/src/pages/Study/bibleVersions/SortVersionsByLanguage.js
+++ b/src/pages/Study/bibleVersions/SortVersionsByLanguage.js
@@ -1,21 +1,20 @@
-
+// SortVersionsByLanguage.js
 const sortVersionsByLanguage = (versionList) => {
   const sortedVersions = {};
 
   versionList.forEach((version) => {
-    const language = version.language?.name || 'Unknown';
-
+    const language = version.language?.name || "Unknown";
     if (!sortedVersions[language]) {
       sortedVersions[language] = [];
     }
-
     sortedVersions[language].push(version);
   });
 
-  // Sort versions alphabetically within each language group by abbreviation
   for (const language in sortedVersions) {
     sortedVersions[language].sort((a, b) => {
-      return a.abbreviation.localeCompare(b.abbreviation);
+      const aAbbr = a.abbreviation || a.id || "";
+      const bAbbr = b.abbreviation || b.id || "";
+      return aAbbr.localeCompare(bAbbr);
     });
   }
 

--- a/src/pages/Study/bookVersions/BookVersionModal.js
+++ b/src/pages/Study/bookVersions/BookVersionModal.js
@@ -14,7 +14,7 @@ const BookVersionModal = ({
   currentBookId
 }) => {
   const [books, setBooks] = useState([]);
-  const [selectedBookId, setSelectedBookId] = useState(currentBookId !== undefined ? currentBookId : undefined);
+  const [selectedBookId, setSelectedBookId] = useState(currentBookId ?? null);
   const [error, setError] = useState(null);
 
   // Separate filters: one for books, one for chapters
@@ -55,29 +55,30 @@ const BookVersionModal = ({
 
   // When opening the modal, if a book is already chosen, start in Chapters view
   useEffect(() => {
-    if (visibilityStatus && currentBookId && selectedBookId === undefined) {
-      setSelectedBookId(currentBookId); // only on first open/init
+    if (visibilityStatus && currentBookId && selectedBookId == null) {
+      setSelectedBookId(currentBookId);
     }
-  }, [visibilityStatus, currentBookId, selectedBookId])
+  }, [visibilityStatus, currentBookId, selectedBookId]);
 
   // Allow Backspace to go back to Books when viewing Chapters
   useEffect(() => {
-    if (!visibilityStatus || !selectedBookId) return;
-    const onKeyDown = (e) => {
+    if (!visibilityStatus || selectedBookId == null) return;
 
+    const onKeyDown = (e) => {
       const el = e.target;
-      const isTypingTarget =
-        el && (
-          el.tagName === "INPUT" ||
+      const typing =
+        el &&
+        (el.tagName === "INPUT" ||
           el.tagName === "TEXTAREA" ||
-          el.isContentEditable
-        );
-      if (e.key === "Backspace" && !isTypingTarget) {
+          el.isContentEditable);
+
+      if (e.key === "Backspace" && !typing) {
         e.preventDefault();
         setSelectedBookId(null);
         setChapterFilterText("");
       }
     };
+
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [visibilityStatus, selectedBookId]);
@@ -102,12 +103,18 @@ const BookVersionModal = ({
   return (
     <div className={visibilityStatus ? "BookModal" : "ModalHidden"} role="dialog" aria-modal="true">
       <section className="ModalHeader">
-        {(selectedBookId !== null && selectedBookId !== undefined) && (
-          <button className="BookVersionBackButton" onClick={backToBooks} aria-label="Back to books">
+        {selectedBookId != null && (
+          <button
+            className="BookVersionBackButton"
+            onClick={backToBooks}
+            aria-label="Back to books"
+          >
             ←
           </button>
         )}
-        <h3 className="ModalTitle">{selectedBookId ? "Chapters" : "Books"}</h3>
+        <h3 className="ModalTitle">
+          {selectedBookId != null ? "Chapters" : "Books"}
+        </h3>
         <h4 className="ModalExitButton" onClick={modalCloseHandler} aria-label="Close modal">
           CANCEL
         </h4>

--- a/src/pages/Study/verseDisplay/Verse.css
+++ b/src/pages/Study/verseDisplay/Verse.css
@@ -11,6 +11,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  min-height: 500px;
 }
 
 .bookChapterHeader {


### PR DESCRIPTION
- Integrated Korean ("KOR") Bible option into the version selector:
  - Added synthetic Korean version entry alongside curated English versions (ASV, BSB, engKJV, WEB, FBV).
  - Mapped underlying KOR version id to a custom backend/ibibles-based data source.

- Implemented static Korean book and chapter metadata:
  - Introduced KOR_BOOKS for displaying Korean/English book labels.
  - Added KOR_CHAPTER_COUNTS to define chapter counts for each book.
  - Ensured chapter ids follow `{bookId}.{chapterNumber}` format (e.g. ge.1, psa.23).

- Updated Book & Chapter selection UX:
  - BookVersionModal now supports:
    - Switching between Books/Chapters views with preserved selection.
    - Filtering books and chapters independently.
    - Back navigation via UI button and Backspace (when not typing).
  - Chapter list component supports filtering by chapter number/text.

- Standardized cross-version navigation:
  - Centralized next/previous chapter logic in `Bible`:
    - Moves within the same book when possible.
    - Jumps from the last chapter of a book to the first chapter of the next book.
    - Jumps from the first chapter of a book to the last chapter of the previous book.
  - Logic works consistently for both api.bible-based versions and Korean static metadata.

- Improved verse rendering:
  - Fetched verse content per verse for non-Korean versions without duplicating verse numbers.
  - Rendered verses in paired layout with styled superscript verse numbers.
  - Added keyboard navigation (←/→) for chapter-level navigation.

- Misc cleanup:
  - Hardened version sorting to handle missing abbreviations.
  - Adjusted version modal filter placeholder copy.
  - Minor safety checks and prop wiring cleanup.