### PR TITLE
Keep verse display area visible and hide navigation arrows when no chapter is selected

### DIFF
--- a/src/pages/Study/verseDisplay/Verse.css
+++ b/src/pages/Study/verseDisplay/Verse.css
@@ -19,6 +19,24 @@
   text-align: center;
 }
 
+/* --- Placeholder state when no chapter is selected --- */
+.chapterTitle {
+  font-size: 1.2rem;
+  font-weight: 500;
+  color: #333;
+}
+
+.chapterTitle.placeholder {
+  color: #aaa;
+  font-style: italic;
+  font-weight: 400;
+  letter-spacing: 0.2px;
+  text-align: center;
+  display: block;
+  margin-top: 40px;
+}
+
+
 .displayArea {
   padding-top: 30px;
   width: 80%;
@@ -41,8 +59,10 @@
 
 /* Container for each single verse inside the pair */
 .verseChunk {
-  display: inline;          /* seamless flow */
-  margin-right: 10px;       /* small gap between verse pairs */
+  display: inline;
+  /* seamless flow */
+  margin-right: 10px;
+  /* small gap between verse pairs */
 }
 
 /* Visual for the numbers we render in JSX */
@@ -57,8 +77,6 @@
 .versesList li::before {
   content: none;
 }
-
-
 
 .navArrow {
   position: fixed;


### PR DESCRIPTION
- Updated Verse component so the display section and layout remain mounted at all times,
  ensuring consistent page structure even before a chapter is chosen.
- Moved the placeholder message ("Select a book and chapter to begin.") into the header
  for a clearer, user-friendly empty state.
- Conditionally render navigation arrows only when a chapter is selected
  and previous/next navigation is available.
- Added new CSS styles for the placeholder state:
  - `.chapterTitle.placeholder` with softer gray color and italicized font.
  - Ensures the placeholder message remains visually distinct without disrupting
    the main layout.
- Refactored Verse.jsx logic to simplify rendering:
  - Introduced `hasChapter` and `showArrows` flags for clearer conditional display.
  - Preserved arrow-key navigation and loading/error handling.
  
This change improves visual continuity and user experience by keeping the reading
area consistent while gracefully hiding navigation controls until they are relevant.