### PR TITLE
Fix navigation bug in BookVersionModal: allow returning to book selection after viewing chapters

### DIFF
--- a/src/pages/Account/Account.css
+++ b/src/pages/Account/Account.css
@@ -6,21 +6,21 @@
 
 .Account {
   background: rgb(22, 0, 0);
-  height: 100vh;
+  min-height: 800px;
 }
 
 .account-content {
   width: 100%;
-  height: 900px;
+  min-height: 800px;
   display: flex;
-  align-items:last center;
+  align-items: center;
   justify-content: center;
 }
 
 
 .account-card {
   position: relative;
-  top: -150px;
+  top: -100px;
   width: min(580px, 100%);
   background-color: rgb(45, 10, 10);
   border: 1px solid rgba(0, 0, 0, .08);
@@ -72,7 +72,7 @@
 .signup-name-flex {
   width: 100%;
   display: flex;
-  justify-content:space-between;
+  justify-content: space-between;
   padding-right: 50px;
 }
 

--- a/src/pages/Account/signUp/SignUp.js
+++ b/src/pages/Account/signUp/SignUp.js
@@ -23,7 +23,7 @@ const SignUp = () => {
             <PageHeader />
             <div className='account-content'>
                 <div className="account-card">
-                    <h1 className="account-title">Sign In</h1>
+                    <h1 className="account-title">Sign Up</h1>
 
                     {error && (
                         <div className="account-error" role="alert">

--- a/src/pages/Study/bookVersions/BookVersionModal.js
+++ b/src/pages/Study/bookVersions/BookVersionModal.js
@@ -55,10 +55,10 @@ const BookVersionModal = ({
 
   // When opening the modal, if a book is already chosen, start in Chapters view
   useEffect(() => {
-    if (visibilityStatus && currentBookId && selectedBookId == null) {
+    if (visibilityStatus && currentBookId) {
       setSelectedBookId(currentBookId);
     }
-  }, [visibilityStatus, currentBookId, selectedBookId]);
+  }, [visibilityStatus, currentBookId]);
 
   // Allow Backspace to go back to Books when viewing Chapters
   useEffect(() => {

--- a/src/pages/Study/verseDisplay/Verse.css
+++ b/src/pages/Study/verseDisplay/Verse.css
@@ -92,11 +92,12 @@
   border: none;
   border-radius: 999px;
   background: rgba(0, 0, 0, 0.08);
+  /* background: white; */
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   cursor: pointer;
   font-size: 1.25rem;
   line-height: 1;
-  backdrop-filter: blur(2px);
+  /* backdrop-filter: blur(2px); */
   transition: background 0.2s, transform 0.1s;
 }
 
@@ -111,11 +112,11 @@
 /* Place them near the content column. The content is centered, so its left edge is (50% - content/2) */
 .navArrowLeft {
   /* keep at least 12px from the viewport edge; otherwise anchor to content edge minus offset */
-  left: max(12px, calc(50% - (var(--content-width) / 2) - var(--arrow-offset)));
+  left: max(12px, calc(45% - (var(--content-width) / 2) - var(--arrow-offset)));
 }
 
 .navArrowRight {
-  right: max(12px, calc(50% - (var(--content-width) / 2) - var(--arrow-offset)));
+  right: max(12px, calc(45% - (var(--content-width) / 2) - var(--arrow-offset)));
 }
 
 /* Hide arrows entirely when they’re not renderable (you already conditionally render them).


### PR DESCRIPTION
## Summary
This pull request fixes a navigation issue in the **BookVersionModal** component where users could not return to the book list once a chapter was selected. The problem affected both English and Korean Bible versions.

## Problem
- After selecting a chapter, pressing the back arrow or Backspace appeared to do nothing.
- The modal would instantly revert to the chapter list view because an effect re-set `selectedBookId` to `currentBookId` whenever the modal was open.
- The only way to reset the state was to switch Bible versions.

## Fix
- Adjusted the `useEffect` dependency logic:
  - The modal now syncs with the current book **only** when the modal opens or when the `currentBookId` actually changes.
  - It no longer overrides user actions like pressing the Back button.
- Verified that both English (api.bible) and Korean (static ibibles) versions now correctly:
  - Open to the chapter list when a book is selected.
  - Return to the book list when Back is pressed.

## Impact
This fix restores expected navigation behavior inside the book/chapter selection modal and improves overall usability and consistency across versions.
