### PR TITLE
feat: implement CommunityBody layout with tab switching + study info …

### DIFF
--- a/src/pages/Community/Community.css
+++ b/src/pages/Community/Community.css
@@ -1,11 +1,12 @@
 .Community {
     width: 100vw;
+    background-color: #F4EEE6;
 }
 
 .CommunityHero {
     /* background-color: #27272780; */
     background-image: url('../../component/images/community/CommunityHero.png');
-    height: 600px;
+    height: 550px;
 
     /* background-blend-mode: saturation; */
     background-position: center;
@@ -45,7 +46,7 @@
 }
 
 .CommunityH3 {
-    margin-top: 100px;
+    margin-top: 90px;
     letter-spacing: 1px;
     font-weight: 100;
     font-size: 14px;

--- a/src/pages/Community/Community.js
+++ b/src/pages/Community/Community.js
@@ -1,5 +1,6 @@
 import PageHeader from '../../component/PageHeader';
 import './Community.css';
+import CommunityBody from './CommunityBody';
 
 const Community = () => {
 
@@ -24,6 +25,7 @@ const Community = () => {
                     Share memos, comment on verses, and walk through Scripture together
                 </h2>
             </div>
+            <CommunityBody/>
         </section>
     );
 };

--- a/src/pages/Community/CommunityBody.css
+++ b/src/pages/Community/CommunityBody.css
@@ -1,0 +1,75 @@
+.CommunityBody {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 50px 50px;
+}
+
+.communityBodyBC {
+    position: relative;
+    display: flex;
+    gap: 20px; 
+    border-bottom: 1px solid #ddd;
+    margin-bottom: 25px;
+}
+
+.communityBodyB {
+    padding: 10px 0;
+    font-size: 18px;
+    font-weight: 500;
+    cursor: pointer;
+    background: none;
+    border: none;
+    color: #444;
+}
+
+.communityBodyB.active {
+    color: #000;
+}
+
+.underline {
+    position: absolute;
+    bottom: -1px;
+    height: 3px;
+    background-color: black;
+    border-radius: 3px;
+    transition: transform 0.35s ease, width 0.35s ease;
+    width: 0; 
+    transform: translateX(0); 
+}
+
+/*
+    Study Cards
+*/
+
+.studyHowSection {
+    margin-top: 40px;
+}
+
+.studyHowCardContainer {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    gap: 30px;
+}
+
+.studyCard {
+    display: flex;
+    align-items: flex-start;
+    gap: 15px;
+}
+
+.studyCardIcon {
+    font-size: 32px;
+}
+
+.studyCardHeader {
+    font-size: 20px;
+    font-weight: 600;
+    margin: 0;
+}
+
+.studyCardContent {
+    margin: 4px 0 0;
+    color: #666;
+}

--- a/src/pages/Community/CommunityBody.js
+++ b/src/pages/Community/CommunityBody.js
@@ -1,0 +1,88 @@
+import { useState, useRef, useEffect } from "react";
+import "./CommunityBody.css";
+
+import { FaPlus } from "react-icons/fa6";
+import { PiBookOpenLight } from "react-icons/pi";
+import { LuNotebookPen } from "react-icons/lu";
+
+const CommunityBody = () => {
+    const [activeTab, setActiveTab] = useState("my");
+
+    const myRef = useRef(null);
+    const discoverRef = useRef(null);
+    const underlineRef = useRef(null);
+
+    useEffect(() => {
+        const tabRef = activeTab === "my" ? myRef : discoverRef;
+        const underline = underlineRef.current;
+
+        if (tabRef.current && underline) {
+            const { offsetLeft, offsetWidth } = tabRef.current;
+
+            underline.style.width = `${offsetWidth}px`;
+            underline.style.transform = `translateX(${offsetLeft}px)`;
+        }
+    }, [activeTab]);
+
+    return (
+        <section className="CommunityBody">
+            <div className="communityBodyBC">
+                <button
+                    ref={myRef}
+                    className={`communityBodyB ${activeTab === "my" ? "active" : ""}`}
+                    onClick={() => setActiveTab("my")}
+                >
+                    My Communities
+                </button>
+
+                <button
+                    ref={discoverRef}
+                    className={`communityBodyB ${activeTab === "discover" ? "active" : ""}`}
+                    onClick={() => setActiveTab("discover")}
+                >
+                    Discover
+                </button>
+
+                <span className="underline" ref={underlineRef} />
+            </div>
+
+            <div className="communityDisplayArea">
+                {activeTab === "my" ? "My communities content…" : "Discover communities…"}
+            </div>
+
+            <section className="studyHowSection">
+                <h3 className="studyHowHeader">
+                    How Community Study Works
+                </h3>
+                <ul className="studyHowCardContainer">
+                    <li className="studyCard">
+                        <FaPlus className="studyCardIcon" />
+                        <div>
+                            <h3 className="studyCardHeader">Create or Join</h3>
+                            <p className="studyCardContent">Start</p>
+                        </div>
+                    </li>
+
+                    <li className="studyCard">
+                        <PiBookOpenLight className="studyCardIcon" />
+                        <div>
+                            <h3 className="studyCardHeader">Read Together</h3>
+                            <p className="studyCardContent">Walk through Scripture in sync</p>
+                        </div>
+                    </li>
+
+                    <li className="studyCard">
+                        <LuNotebookPen className="studyCardIcon" />
+                        <div>
+                            <h3 className="studyCardHeader">Share Memos</h3>
+                            <p className="studyCardContent">Record insights visible to all</p>
+                        </div>
+                    </li>
+
+                </ul>
+            </section>
+        </section>
+    );
+};
+
+export default CommunityBody;


### PR DESCRIPTION

✔ What’s Included

Implemented tab switching between My Communities and Discover

Added animated underline indicator synced with active tab using refs + useEffect

Added placeholder content for each tab (to be replaced with real data)

Built “How Community Study Works” section with icons and descriptive text

Added full CSS for:

layout container

tab bar and underline

study info cards

icon styling and spacing

Ensured responsive spacing and consistent typography with site theme

❗ Not Included (Coming in next PRs)

Community list rendering

API fetching for “My Communities” / “Discover”

Routing or modal for creating a new community

Button interactions and click behaviors

Loading + empty states