### PR TITLE
Add Community hero section and CommunityBody card grid

### DIFF
--- a/src/pages/Community/Community.css
+++ b/src/pages/Community/Community.css
@@ -52,7 +52,7 @@
     font-size: 14px;
 }
 
-.buttonContainer{
+.buttonContainer {
     display: flex;
     margin-top: 25px;
     gap: 25px;
@@ -68,5 +68,4 @@
     font-weight: 500;
     cursor: pointer;
 }
-
 

--- a/src/pages/Community/Community.js
+++ b/src/pages/Community/Community.js
@@ -1,3 +1,4 @@
+import Footer from '../../component/Footer';
 import PageHeader from '../../component/PageHeader';
 import './Community.css';
 import CommunityBody from './CommunityBody';
@@ -26,6 +27,7 @@ const Community = () => {
                 </h2>
             </div>
             <CommunityBody/>
+            <Footer/>
         </section>
     );
 };

--- a/src/pages/Community/CommunityBody.css
+++ b/src/pages/Community/CommunityBody.css
@@ -43,7 +43,8 @@ Study Cards
 */
 
 .studyHowSection {
-    margin-top: 40px;
+    margin-top: 60px;
+    margin-bottom: 40px;
     width: 100%;
 }
 
@@ -81,4 +82,48 @@ Study Cards
 .studyCardContent {
     margin: 4px 0 0;
     color: #666;
+}
+
+.communityShowMoreWrapper {
+    display: flex;
+    justify-content: center;
+    margin-top: 16px;
+}
+
+/* Show More button styling */
+.communityShowMoreButton {
+    padding: 10px 18px;
+    border-radius: 6px;
+    border: 1px solid #ccc;
+    background-color: #f3f0ea;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.2s ease, transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.communityShowMoreButton:hover {
+    background-color: #e6ded2;
+    transform: translateY(-1px);
+    box-shadow: 0 2px 4px rgba(0,0,0,0.08);
+}
+
+
+/* Will change the grid template to display 2 in smaller viewport and 1 in mobile */
+.communityCardGrid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 10px;
+}
+
+@media (max-width: 1024px) {
+    .communityCardGrid {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .communityCardGrid {
+        grid-template-columns: 1fr;
+    }
 }

--- a/src/pages/Community/CommunityBody.js
+++ b/src/pages/Community/CommunityBody.js
@@ -4,13 +4,87 @@ import "./CommunityBody.css";
 import { FaPlus } from "react-icons/fa6";
 import { PiBookOpenLight } from "react-icons/pi";
 import { LuNotebookPen } from "react-icons/lu";
+import CommunityCard from "./CommunityCard";
 
 const CommunityBody = () => {
     const [activeTab, setActiveTab] = useState("my");
+    const [showAllMyCommunities, setShowAllMyCommunities] = useState(false);
+    const [visibleCount, setVisibleCount] = useState(3); 
 
     const myRef = useRef(null);
     const discoverRef = useRef(null);
     const underlineRef = useRef(null);
+    const gridRef = useRef(null);
+
+    // Demo data – later to be replaced with data from API / props
+    const myCommunities = [
+        {
+            header: "Young Adults Group",
+            subheader: "Weekly Bible study with KTPC",
+            content: "Demo Community Card",
+            members: 6,
+            lastActive: "17 hours ago",
+            role: "Owner",
+        },
+        {
+            header: "Morning Devotionals Confirming the animation for length",
+            subheader: "Start the day in the Word Confirming the animation for length",
+            content: "Short daily readings and reflections. Confirming the animation for length",
+            members: 12,
+            lastActive: "2 hours ago",
+            role: "Member",
+        },
+        {
+            header: "Korean-English Study Group",
+            subheader: "Bilingual Bible reading and sharing",
+            content: "Share insights in both Korean and English.",
+            members: 8,
+            lastActive: "1 day ago",
+            role: "Owner",
+        },
+        {
+            header: "Friday Night Fellowship",
+            subheader: "End the week with worship and study",
+            content: "Hybrid in-person and online gatherings.",
+            members: 15,
+            lastActive: "3 days ago",
+            role: "Member",
+        },
+    ];
+
+    // Sync visibleCount with actual grid-template-columns
+    useEffect(() => {
+        const updateVisibleFromGrid = () => {
+            if (!gridRef.current) return;
+
+            const styles = window.getComputedStyle(gridRef.current);
+            const templateColumns = styles.getPropertyValue("grid-template-columns");
+
+            if (!templateColumns) return;
+
+            // "1fr 1fr 1fr" to ["1fr","1fr","1fr"] → 3
+            const cols = templateColumns
+                .trim()
+                .split(/\s+/)
+                .filter(Boolean).length;
+
+            // Safety: don't exceed number of communities
+            const count = Math.min(cols, myCommunities.length);
+
+            setVisibleCount(count);
+        };
+
+        updateVisibleFromGrid();
+        window.addEventListener("resize", updateVisibleFromGrid);
+
+        return () => {
+            window.removeEventListener("resize", updateVisibleFromGrid);
+        };
+    }, [myCommunities.length]);
+
+    const visibleMyCommunities = showAllMyCommunities
+        ? myCommunities
+        : myCommunities.slice(0, visibleCount);
 
     useEffect(() => {
         const tabRef = activeTab === "my" ? myRef : discoverRef;
@@ -47,19 +121,50 @@ const CommunityBody = () => {
             </div>
 
             <div className="communityDisplayArea">
-                {activeTab === "my" ? "My communities content…" : "Discover communities…"}
+                {activeTab === "my" ? (
+                    <>
+                        <section className="communityCardGrid" ref={gridRef}>
+                            {visibleMyCommunities.map((community, index) => (
+                                <CommunityCard
+                                    key={index}
+                                    header={community.header}
+                                    subheader={community.subheader}
+                                    content={community.content}
+                                    members={community.members}
+                                    lastActive={community.lastActive}
+                                    role={community.role}
+                                />
+                            ))}
+                        </section>
+
+                        {!showAllMyCommunities &&
+                            myCommunities.length > visibleCount && (
+                                <div className="communityShowMoreWrapper">
+                                    <button
+                                        className="communityShowMoreButton"
+                                        onClick={() => setShowAllMyCommunities(true)}
+                                    >
+                                        Show More
+                                    </button>
+                                </div>
+                            )}
+                    </>
+                ) : (
+                    "Discover communities…"
+                )}
             </div>
 
             <section className="studyHowSection">
-                <h3 className="studyHowHeader">
-                    How Community Study Works
-                </h3>
+                <h3 className="studyHowHeader">How Community Study Works</h3>
                 <ul className="studyHowCardContainer">
                     <li className="studyCard">
                         <FaPlus className="studyCardIcon" />
                         <div>
                             <h3 className="studyCardHeader">Create or Join</h3>
-                            <p className="studyCardContent">Start your own study group or join a community that matches your interests. Connect quickly and begin studying together right away.</p>
+                            <p className="studyCardContent">
+                                Start your own study group or join a community that matches your
+                                interests. Connect quickly and begin studying together right away.
+                            </p>
                         </div>
                     </li>
 
@@ -67,7 +172,10 @@ const CommunityBody = () => {
                         <PiBookOpenLight className="studyCardIcon" />
                         <div>
                             <h3 className="studyCardHeader">Read Together</h3>
-                            <p className="studyCardContent">Follow the same passages as your community and move through Scripture in sync, making study and discussion simple and unified.</p>
+                            <p className="studyCardContent">
+                                Follow the same passages as your community and move through
+                                Scripture in sync, making study and discussion simple and unified.
+                            </p>
                         </div>
                     </li>
 
@@ -75,10 +183,12 @@ const CommunityBody = () => {
                         <LuNotebookPen className="studyCardIcon" />
                         <div>
                             <h3 className="studyCardHeader">Share Memos</h3>
-                            <p className="studyCardContent">Write reflections and insights in a shared memo space where everyone can see, contribute, and grow together.</p>
+                            <p className="studyCardContent">
+                                Write reflections and insights in a shared memo space where
+                                everyone can see, contribute, and grow together.
+                            </p>
                         </div>
                     </li>
-
                 </ul>
             </section>
         </section>

--- a/src/pages/Community/CommunityCard.css
+++ b/src/pages/Community/CommunityCard.css
@@ -1,0 +1,92 @@
+.CommunityCards {
+    border: 1px solid transparent;
+    border-image: linear-gradient(to right, #ecbc7a, transparent) 1;
+    background-color: #faf6f0;
+    box-shadow: inset;
+
+    padding: 20px;
+    height: 280px;
+
+    display: flex;
+    flex-direction: column;
+
+    font-family: Arial, Helvetica, sans-serif;
+
+    /* important for grid: allow card to shrink to its 1fr track */
+    min-width: 0;
+}
+
+/* Base text styles */
+.communityCardHeader {
+    font-size: 20px;
+    font-weight: 800;
+    padding-bottom: 5px;
+}
+
+.communityCardSubHeader {
+    font-family: Arial, Helvetica, sans-serif;
+    font-weight: 500;
+    font-size: 16px;
+    padding-bottom: 65px;
+}
+
+.communityCardContent {
+    font-size: 14px;
+    padding-bottom: 3px;
+}
+
+.communityCardContent:last-of-type {
+    padding-bottom: 5px;
+}
+
+/* line viewport: fixed width, hides overflow */
+.marqueeLine {
+    display: block;
+    width: 100%;
+    position: relative;
+    overflow: hidden;
+    white-space: nowrap;
+    min-width: 0;
+}
+
+/* inner text that slides */
+.marqueeInner {
+    display: inline-block;
+    padding-right: 2rem; 
+}
+
+/* per-line hover: only this line animates when hovered */
+.marqueeScrollable:hover .marqueeInner {
+    animation: cardTextMarquee 15s linear infinite;
+    will-change: transform;
+    cursor: default;
+}
+
+/* right → left slow scroll */
+@keyframes cardTextMarquee {
+    0% {
+        transform: translateX(0);
+    }
+    100% {
+        transform: translateX(-100%);
+    }
+}
+
+.communityCardRole {
+    display: block;
+    width: fit-content;
+    background-color: #d6cfc6;
+    padding: 5px 8px;
+    margin-bottom: 15px;
+
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.communityCardEnterButton {
+    background-color: black;
+    color: white;
+    padding: 10px;
+    border-radius: 5px;
+    font-size: 16px;
+}

--- a/src/pages/Community/CommunityCard.js
+++ b/src/pages/Community/CommunityCard.js
@@ -1,0 +1,81 @@
+import { useRef, useEffect, useState } from "react";
+import "./CommunityCard.css";
+
+const CommunityCard = (props) => {
+    const headerRef = useRef(null);
+    const subheaderRef = useRef(null);
+    const contentRef = useRef(null);
+
+    const [overflow, setOverflow] = useState({
+        header: false,
+        subheader: false,
+        content: false,
+    });
+
+    useEffect(() => {
+        const isOverflowing = (el) => {
+            if (!el) return false;
+            return el.scrollWidth > el.clientWidth;
+        };
+
+        const checkOverflow = () => {
+            setOverflow({
+                header: isOverflowing(headerRef.current),
+                subheader: isOverflowing(subheaderRef.current),
+                content: isOverflowing(contentRef.current),
+            });
+        };
+
+        checkOverflow();
+        window.addEventListener("resize", checkOverflow);
+
+        return () => {
+            window.removeEventListener("resize", checkOverflow);
+        };
+    }, []);
+
+    return (
+        <section className="CommunityCards">
+            <h2
+                ref={headerRef}
+                className={`communityCardHeader marqueeLine ${
+                    overflow.header ? "marqueeScrollable" : ""
+                }`}
+            >
+                <span className="marqueeInner">{props.header}</span>
+            </h2>
+
+            <h3
+                ref={subheaderRef}
+                className={`communityCardSubHeader marqueeLine ${
+                    overflow.subheader ? "marqueeScrollable" : ""
+                }`}
+            >
+                <span className="marqueeInner">{props.subheader}</span>
+            </h3>
+
+            {props.content ? (
+                <p
+                    ref={contentRef}
+                    className={`communityCardContent marqueeLine ${
+                        overflow.content ? "marqueeScrollable" : ""
+                    }`}
+                >
+                    <span className="marqueeInner">{props.content}</span>
+                </p>
+            ) : null}
+
+            <p className="communityCardContent">
+                {props.members} members, {props.lastActive}
+            </p>
+
+            <span className="communityCardRole">{props.role}</span>
+
+            <button className="communityCardEnterButton">
+                Enter Community
+            </button>
+        </section>
+    );
+};
+
+export default CommunityCard;

--- a/src/pages/Community/communityPlanning.txt
+++ b/src/pages/Community/communityPlanning.txt
@@ -1,0 +1,18 @@
+커뮤니티 기능을 개발하면서 고민해봐야 할점들:
+
+지금까지 Hardwire를 짜면서 생각해본 properties list (추후 추가 예정) - 
+community title (header), subheader, content(설명란), # of members, last active, role (position)
+
+이중 포지션 측면에서 고려해야할 사항들은
+Owner - 커뮤니티를 창설한 사람. Leader 권한을 위임하거나 해임할수있다.
+Leader - 커뮤니티를 이끌어갈, Admin 권한을 갖고있는 사람. 가입 신청을 처리하고 상황에 따라 멤버 추방이 가능하다
+Member - 일반 멤버로써 Read, Write, Update 권한을 가지고 있다
+
+이정도라고 본다면, Owner 롤은 기본적으로 커뮤니티를 창설한 사람에게 주어지고 위임가능성은 추후 논의해봐야한다.
+Owner는 Leader 롤 과 같은 권한을 가지고 있고 Leader 들을 위임하거나 해임할수있다. 한번에 여러명의 leader 포지션이
+존재할수 있고 Leader 포지션이 없는 커뮤니티도 존재할수있다.
+
+이 포지션 관련된 정보들은 아마도 두개의 property로 나뉘어서 저장하면 좋을거같다.
+Community db 안에 Owner property, Leader property 로 나뉘어서 저장하고
+이에 해당하는 사람들에 대해서는 이에 해당돼는 권한을 부여하고 그렇지 않은 경우에는 member 권한을 부여하면 될듯.
+


### PR DESCRIPTION
This PR adds the full UI structure for the Community page, including the hero section, tab system, and responsive community card grid.

✔ Included

Community hero with header, subheader, tagline, and two CTAs

Background hero image + centered layout styling

Tab navigation for My Communities / Discover with animated underline

Responsive card grid (3/2/1 columns) synced to viewport

“Show More” button to reveal additional communities

New CommunityCard component with:

Overflow detection per line

Hover marquee animation for long text

Role badge and “Enter Community” button

Completed “How Community Study Works” section with icons + short descriptions

❗ Not Included

Real data loading

Routing for buttons / card actions

Discover page UI

Empty/loading states