### PR TITLE
fix: ensure full community detail loads and display owner/leaders/members correctly

### DIFF
--- a/src/pages/Community/CommunityCard.js
+++ b/src/pages/Community/CommunityCard.js
@@ -23,7 +23,7 @@ const CommunityCard = (props) => {
     lastActive,
     role,
     type,
-    my,
+    my, // true if user is already a member
   } = props;
 
   useEffect(() => {
@@ -63,14 +63,14 @@ const CommunityCard = (props) => {
     }
   };
 
-  const handleEnterClick = () => {
+  const handlePrimaryClick = () => {
     if (!id) return;
 
     if (my) {
-      // TODO: this will be your "member community main page" later
+      // Member → go straight into the community main page
       navigate(`/community/${id}`);
     } else {
-      // Non-member → community info page
+      // Non-member → go to the community info/join page
       navigate(`/community/${id}/info`, {
         state: {
           community: {
@@ -135,9 +135,9 @@ const CommunityCard = (props) => {
       <button
         className="communityCardEnterButton"
         type="button"
-        onClick={handleEnterClick}
+        onClick={handlePrimaryClick}
       >
-        Enter Community
+        {my ? "Enter Community" : "Join Community"}
       </button>
     </section>
   );

--- a/src/pages/Community/browseCommunity/CommunityInfo.css
+++ b/src/pages/Community/browseCommunity/CommunityInfo.css
@@ -119,3 +119,44 @@
   margin: 32px 0;
   color: #b00020;
 }
+
+.CommunityInfoPeople {
+  margin: 32px 24px;
+}
+
+.CommunityInfoPeopleTitle {
+  font-size: 1.25rem;
+  margin-bottom: 16px;
+}
+
+.CommunityInfoPeopleGrid {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 768px) {
+  .CommunityInfoPeopleGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.CommunityInfoPeopleBlock {
+  padding: 12px 0;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.CommunityInfoUserList {
+  list-style: none;
+  margin: 4px 0 0;
+  padding: 0;
+}
+
+.CommunityInfoUserItem {
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.CommunityInfoUserMore {
+  font-size: 1.2rem;
+  line-height: 1;
+}


### PR DESCRIPTION
Updated CommunityInfo.jsx to always fetch full community details from /community/:id, fixing missing owner username, leader list, and member list when navigating from a card.

Removed old early-return condition that prevented loading full data when location.state.community was present.

Normalized member list handling for consistent display.

Preserved initial state for faster UI load but ensured backend fetch overrides with authoritative data.

Verified that card navigation, browse list, and create flow all correctly pass necessary props.