### PR TITLE
feat: add community forum structure, routing, layout, and MyCommunity page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,6 +18,7 @@ import CommunityInfo from "./pages/Community/browseCommunity/CommunityInfo";
 import { AuthProvider } from "./component/context/AuthContext";
 import { NotificationProvider } from "./component/context/NotificationContext";
 import { ToastProvider } from "./component/context/ToastContext";
+import MyCommunity from "./pages/Community/myCommunity/MyCommunity";
 
 function App() {
   return (
@@ -41,6 +42,7 @@ function App() {
                 <Route path="/notifications" element={<Notifications />} />
                 <Route path="/profile" element={<Profile />} />
                 <Route path="/community/:communityId/info" element={<CommunityInfo />} />
+                <Route path="/community/:communityId/my-posts" element={<MyCommunity/>}/>
               </Routes>
             </ToastProvider>
           </NotificationProvider>

--- a/src/pages/Community/CommunityBody.js
+++ b/src/pages/Community/CommunityBody.js
@@ -29,23 +29,39 @@ const CommunityBody = () => {
   const [myCommunities, setMyCommunities] = useState([]);
   const [discoverCommunities, setDiscoverCommunities] = useState([]);
 
-  // --- My Communities ---
   useEffect(() => {
     fetch("http://localhost:4000/community/my", {
       credentials: "include",
     })
-      .then((res) => res.json())
+      .then((res) => {
+        console.log("GET /community/my status:", res.status);
+        return res.json();
+      })
       .then((data) => {
-        if (!data.ok) return;
-        const mapped = data.communities.map((c) => ({
-          ...c,
-          lastActive: formatLastActive(c.lastActivityAt || c.lastActive),
-          my: true,
+        console.log("GET /community/my data:", data);
+
+        if (!data.ok) {
+          console.warn("/community/my returned not ok:", data.error);
+          return;
+        }
+
+        const mapped = (data.communities || []).map((c) => ({
+          id: c.id,                                  // from server
+          header: c.header,
+          subheader: c.subheader,
+          content: c.content,
+          type: c.type,
+          members: c.members,                        // number from membersCount
+          lastActive: formatLastActive(c.lastActivityAt),
+          role: c.role,
+          my: true,                                  // force true on My tab
         }));
+
         setMyCommunities(mapped);
       })
-      .catch((err) => console.error(err));
+      .catch((err) => console.error("[/community/my fetch error]", err));
   }, []);
+
 
   // --- Discover Communities ---
   useEffect(() => {

--- a/src/pages/Community/CommunityCard.js
+++ b/src/pages/Community/CommunityCard.js
@@ -67,10 +67,10 @@ const CommunityCard = (props) => {
     if (!id) return;
 
     if (my) {
-      // Member → go straight into the community main page
-      navigate(`/community/${id}`);
+      // Member → go to my-posts in this community
+      navigate(`/community/${id}/my-posts`);
     } else {
-      // Non-member → go to the community info/join page
+      // Non-member → info/join page
       navigate(`/community/${id}/info`, {
         state: {
           community: {
@@ -88,22 +88,21 @@ const CommunityCard = (props) => {
     }
   };
 
+
   return (
     <section className="CommunityCards">
       <h2
         ref={headerRef}
-        className={`communityCardHeader marqueeLine ${
-          overflow.header ? "marqueeScrollable" : ""
-        }`}
+        className={`communityCardHeader marqueeLine ${overflow.header ? "marqueeScrollable" : ""
+          }`}
       >
         <span className="marqueeInner">{header}</span>
       </h2>
 
       <h3
         ref={subheaderRef}
-        className={`communityCardSubHeader marqueeLine ${
-          overflow.subheader ? "marqueeScrollable" : ""
-        }`}
+        className={`communityCardSubHeader marqueeLine ${overflow.subheader ? "marqueeScrollable" : ""
+          }`}
       >
         <span className="marqueeInner">{subheader}</span>
       </h3>
@@ -111,9 +110,8 @@ const CommunityCard = (props) => {
       {content ? (
         <p
           ref={contentRef}
-          className={`communityCardContent marqueeLine ${
-            overflow.content ? "marqueeScrollable" : ""
-          }`}
+          className={`communityCardContent marqueeLine ${overflow.content ? "marqueeScrollable" : ""
+            }`}
         >
           <span className="marqueeInner">{content}</span>
         </p>

--- a/src/pages/Community/myCommunity/CommunityLayout.css
+++ b/src/pages/Community/myCommunity/CommunityLayout.css
@@ -1,0 +1,55 @@
+/* --- Layout container --- */
+.CommunityLayout {
+  background: #F4EEE6;   /* matches your community pages */
+  min-height: 100vh;
+  padding: 40px 80px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* --- Page header --- */
+.communityLayoutHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.communityLayoutTitle {
+  font-family: Georgia, serif;
+  font-size: 40px;
+  font-weight: 500;
+  color: #2c2c2c;
+  margin: 0;
+}
+
+/* --- Tabs navigation --- */
+.communityLayoutTabs {
+  display: flex;
+  gap: 32px;
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 12px;
+}
+
+.tabLink {
+  font-size: 18px;
+  font-weight: 400;
+  color: #5a5a5a;
+  text-decoration: none;
+  padding-bottom: 6px;
+  transition: color 0.2s ease;
+}
+
+.tabLink:hover {
+  color: #000;
+}
+
+.tabLink.active {
+  color: #000;
+  font-weight: 600;
+  border-bottom: 2px solid #000;
+}
+
+/* --- Outlet body --- */
+.communityLayoutBody {
+  background: white;

--- a/src/pages/Community/myCommunity/CommunityLayout.js
+++ b/src/pages/Community/myCommunity/CommunityLayout.js
@@ -1,0 +1,44 @@
+import { NavLink, Outlet, useParams } from "react-router-dom";
+import "./CommunityLayout.css";
+import PageHeader from "../../../component/PageHeader";
+
+const CommunityLayout = () => {
+    const { communityId } = useParams();
+
+    return (
+        <section className="CommunityLayout">
+            <PageHeader />
+            <header className="communityLayoutHeader">
+                <h1 className="communityLayoutTitle">Community</h1>
+                {/* later you can show the actual community name once fetched */}
+            </header>
+
+            <nav className="communityLayoutTabs">
+                <NavLink
+                    end
+                    to={`/community/${communityId}`}
+                    className={({ isActive }) =>
+                        isActive ? "tabLink active" : "tabLink"
+                    }
+                >
+                    Overview
+                </NavLink>
+                <NavLink
+                    to={`/community/${communityId}/my-posts`}
+                    className={({ isActive }) =>
+                        isActive ? "tabLink active" : "tabLink"
+                    }
+                >
+                    My Posts
+                </NavLink>
+                {/* You can add more tabs later: /posts, /members, etc. */}
+            </nav>
+
+            <main className="communityLayoutBody">
+                <Outlet />
+            </main>
+        </section>
+    );
+};
+
+export default CommunityLayout;

--- a/src/pages/Community/myCommunity/MyCommunity.css
+++ b/src/pages/Community/myCommunity/MyCommunity.css
@@ -1,0 +1,119 @@
+.ForumContainer {
+    background: #F4EEE6;
+    min-height: 100vh;
+    font-family: "Inter", sans-serif;
+}
+
+.ForumHeader,
+.ForumSubHeader {
+    color: white;
+    font-family: "Georgia", serif;
+    letter-spacing: 1px;
+}
+
+.ForumHeader {
+    font-size: 42px;
+}
+
+.ForumSubHeader {
+    font-size: 24px;
+}
+
+.ForumHero {
+    background-image: url("../../../component/images/community/CommunityDefaultHero.png");
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+    min-height: 400px;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: end;
+    padding: 24px 48px;
+    gap: 12px;
+}
+
+.ForumTabs {
+    display: flex;
+    gap: 24px;
+    margin-bottom: 32px;
+}
+
+.ForumTabs button {
+    background: none;
+    border: none;
+    font-size: 18px;
+    padding-bottom: 6px;
+    cursor: pointer;
+    color: #5A5A5A;
+}
+
+.ForumTabs .active {
+    border-bottom: 2px solid #000;
+    color: #000;
+}
+
+.NewPostButton {
+    background: black;
+    color: white;
+    padding: 10px 22px;
+    border-radius: 6px;
+    border: none;
+    cursor: pointer;
+    margin-bottom: 24px;
+}
+
+.ForumTable {
+    width: 100%;
+    background: white;
+    border-radius: 10px;
+    padding: 0;
+    border-collapse: collapse;
+    overflow: hidden;
+}
+
+.ForumTable th {
+    text-align: left;
+    padding: 18px;
+    font-weight: 600;
+    background: #fafafa;
+}
+
+.ForumTable td {
+    padding: 16px 18px;
+    border-top: 1px solid #e6e6e6;
+    vertical-align: top;
+}
+
+.topic .title {
+    font-weight: 600;
+}
+
+.topic .subtitle {
+    margin-top: 4px;
+    color: #6a6a6a;
+    font-size: 14px;
+}
+
+.Tag {
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+}
+
+.Tag.general {
+    background: #c8d1b2;
+}
+
+.Tag.questions {
+    background: #8BBF7F;
+}
+
+.Tag.announcements {
+    background: #d3a78c;
+}
+
+.Tag.feedback {
+    background: #b9a5d6;
+}

--- a/src/pages/Community/myCommunity/MyCommunity.js
+++ b/src/pages/Community/myCommunity/MyCommunity.js
@@ -1,0 +1,124 @@
+
+import { useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import "./MyCommunity.css";
+
+
+const MyCommunity = () => {
+    const { communityId } = useParams();
+    const [posts, setPosts] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [err, setErr] = useState("");
+
+
+    useEffect(() => {
+        // TEMP: no fetch yet, we just use the static example below
+    }, [communityId]);
+
+
+    return (
+        <section className="ForumContainer">
+            <div className="ForumHero">
+                <h1 className="ForumHeader">
+                    {/*Temporary Header. Needs to be replaced with actual community name when API is ready */}
+                    Temporary Header
+                </h1>
+                <h2 className="ForumSubHeader">
+                    {/*Temporary Subheader */}
+                    Temporary SubHeader
+                </h2>
+            </div>
+            <div className="ForumActions">
+                <button className="NewPostButton">New Post</button>
+            </div>
+
+            {err && <p className="communityError">{err}</p>}
+            {loading && <p>Loading…</p>}
+
+            {!loading && posts.length === 0 && !err && (
+                <p>You don’t have any posts in this community yet.</p>
+            )}
+
+            {!loading && posts.length > 0 && (
+                <table className="ForumTable">
+                    <thead>
+                        <tr>
+                            <th>Topic</th>
+                            <th>Category</th>
+                            <th>Replies</th>
+                            <th>Activity</th>
+                        </tr>
+                    </thead>
+
+                    <tbody>
+                        {posts.map((post) => (
+                            <tr key={post.id}>
+                                <td className="topic">
+                                    <div className="title">{post.title}</div>
+                                    <div className="subtitle">{post.subtitle}</div>
+                                </td>
+                                <td>
+                                    <span className={`Tag ${post.categoryClass || "general"}`}>
+                                        {post.category}
+                                    </span>
+                                </td>
+                                <td>{post.replyCount}</td>
+                                <td>{post.activityText}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            )}
+
+            {/* temporary hard-coded example. don’t have API yet */}
+            {posts.length === 0 && !loading && !err && (
+                <table className="ForumTable">
+                    <thead>
+                        <tr>
+                            <th>Topic</th>
+                            <th>Category</th>
+                            <th>Replies</th>
+                            <th>Activity</th>
+                        </tr>
+                    </thead>
+
+                    <tbody>
+                        <tr>
+                            <td className="topic">
+                                <div className="title">Welcome to the community!</div>
+                                <div className="subtitle">We’re excited to have you here.</div>
+                            </td>
+                            <td><span className="Tag general">General</span></td>
+                            <td>1</td>
+                            <td>2h ago</td>
+                        </tr>
+
+                        <tr>
+                            <td className="topic">
+                                <div className="title">How do I reset my password?</div>
+                                <div className="subtitle">
+                                    I forgot my password and need to reset it.
+                                </div>
+                            </td>
+                            <td><span className="Tag questions">Questions</span></td>
+                            <td>3</td>
+                            <td>5h ago</td>
+                        </tr>
+
+                        <tr>
+                            <td className="topic">
+                                <div className="title">New features are coming soon</div>
+                                <div className="subtitle">Here's a sneak peek.</div>
+                            </td>
+                            <td><span className="Tag announcements">Announcements</span></td>
+                            <td>1</td>
+                            <td>1d ago</td>
+                        </tr>
+                    </tbody>
+                </table>
+            )}
+        </section>
+    );
+};
+
+export default MyCommunity;


### PR DESCRIPTION
### Added
- CommunityLayout component (with tab navigation, shared layout, and styling)
- MyCommunity page with forum table, hero header, temp static data, and dedicated CSS file
- Route: `/community/:communityId/my-posts` → loads MyCommunity inside layout

### Updated
- App.js routing now includes MyCommunity and supports nested community paths
- CommunityBody:
  - Fixed incorrect double `.json()` call
  - Improved logging for `/community/my` responses
  - Normalized mapped community objects
- CommunityCard:
  - Members now navigate to `/community/:id/my-posts` instead of the old `/community/:id`
  - Cleaned redundant className merges
  - Improved navigation flow between member and non-member states

### Styling
- Added `CommunityLayout.css` with full layout UI (tabs, header, outlet body)
- Added `MyCommunity.css` with complete forum UI (hero, table, tags, actions, typography)