### PR TITLE
feat(community): add poll posts, post detail view, and hero hero uploads

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import CommunityWalkthrough from "./pages/Community/CommunityWalkthrough";
 import Notifications from "./pages/Account/userMenu/Notifications";
 import Profile from "./pages/Account/userMenu/Profile";
 import CommunityInfo from "./pages/Community/browseCommunity/CommunityInfo";
+import PostDetail from "./pages/Community/myCommunity/PostDetail";
 
 import { AuthProvider } from "./component/context/AuthContext";
 import { NotificationProvider } from "./component/context/NotificationContext";
@@ -42,7 +43,8 @@ function App() {
                 <Route path="/notifications" element={<Notifications />} />
                 <Route path="/profile" element={<Profile />} />
                 <Route path="/community/:communityId/info" element={<CommunityInfo />} />
-                <Route path="/community/:communityId/my-posts" element={<MyCommunity/>}/>
+                <Route path="/community/:communityId/my-posts" element={<MyCommunity />} />
+                <Route path="/community/:communityId/posts/:postId" element={<PostDetail />} />
               </Routes>
             </ToastProvider>
           </NotificationProvider>

--- a/src/pages/Community/myCommunity/MyCommunity.css
+++ b/src/pages/Community/myCommunity/MyCommunity.css
@@ -563,6 +563,14 @@
   height: 14px;
 }
 
+.ForumRow {
+  cursor: pointer;
+}
+
+.ForumRow:hover {
+  background-color: #faf5ec;
+}
+
 
 /* ===========================
    Mobile tweaks

--- a/src/pages/Community/myCommunity/MyCommunity.js
+++ b/src/pages/Community/myCommunity/MyCommunity.js
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useAuth } from "../../../component/context/AuthContext";
 import "./MyCommunity.css";
@@ -12,10 +12,10 @@ const API_BASE =
 
 const DEFAULT_HERO =
     "/community/CommunityDefaultHero.png";
-// or require(...) / your existing relative path exposed via public
 
 const MyCommunity = () => {
     const { communityId } = useParams();
+    const navigate = useNavigate();
     const { user } = useAuth();
 
     const [community, setCommunity] = useState(null);
@@ -29,6 +29,10 @@ const MyCommunity = () => {
     const fileInputRef = useRef(null);
     const [uploadingHero, setUploadingHero] = useState(false);
     const [uploadError, setUploadError] = useState("");
+
+    const handleRowClick = (postId) => {
+        navigate(`/community/${communityId}/posts/${postId}`);
+    };
 
     const fetchCommunity = useCallback(async () => {
         try {
@@ -281,7 +285,11 @@ const MyCommunity = () => {
                         </thead>
                         <tbody>
                             {posts.map((post) => (
-                                <tr key={post.id}>
+                                <tr
+                                    key={post.id}
+                                    className="ForumRow"
+                                    onClick={() => handleRowClick(post.id)}
+                                >
                                     <td className="topic">
                                         <div className="title">{post.title}</div>
                                         <div className="subtitle">{post.subtitle}</div>
@@ -296,6 +304,7 @@ const MyCommunity = () => {
                                 </tr>
                             ))}
                         </tbody>
+
                     </table>
                 )}
 

--- a/src/pages/Community/myCommunity/PostDetail.css
+++ b/src/pages/Community/myCommunity/PostDetail.css
@@ -1,0 +1,56 @@
+.ForumHero--small {
+  min-height: 220px;
+}
+
+.PostDetailBody {
+  max-width: 800px;
+  width: 80%;
+  margin: 0 auto 40px;
+}
+
+.PostDetailHeader {
+  margin-bottom: 16px;
+}
+
+.PostDetailTitle {
+  font-size: 24px;
+  margin-top: 8px;
+  margin-bottom: 12px;
+}
+
+.PostDetailMetaRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.PostDetailMetaText {
+  font-size: 13px;
+  color: #666;
+}
+
+.PostDetailContent p {
+  white-space: pre-line;
+  line-height: 1.6;
+  font-size: 15px;
+  color: #333;
+}
+
+.PostDetailSubTitle {
+  font-size: 16px;
+  margin-top: 20px;
+  margin-bottom: 8px;
+}
+
+.PostDetailRepliesEmpty {
+  font-size: 14px;
+  color: #777;
+}
+
+.PostDetailBreadcrumb {
+  color: #f9f4ea;
+  font-size: 14px;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}

--- a/src/pages/Community/myCommunity/PostDetail.js
+++ b/src/pages/Community/myCommunity/PostDetail.js
@@ -1,0 +1,373 @@
+import { useEffect, useState, useCallback } from "react";
+import { useParams, useNavigate, Link } from "react-router-dom";
+import PageHeader from "../../../component/PageHeader";
+import Footer from "../../../component/Footer";
+import Time from "../../../component/utils/Time";
+import "./MyCommunity.css";
+
+const API_BASE =
+    process.env.REACT_APP_API_BASE_URL || "http://localhost:4000";
+
+const PostDetail = () => {
+    const { communityId, postId } = useParams();
+    const navigate = useNavigate();
+
+    const [post, setPost] = useState(null);
+    const [community, setCommunity] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [err, setErr] = useState("");
+
+    const [pollResults, setPollResults] = useState(null);
+    const [myVotes, setMyVotes] = useState([]);
+    const [voting, setVoting] = useState(false);
+    const [voteError, setVoteError] = useState("");
+
+    const [replies, setReplies] = useState([]);
+    const [replyBody, setReplyBody] = useState("");
+    const [repliesLoading, setRepliesLoading] = useState(true);
+    const [replyError, setReplyError] = useState("");
+    const [replySubmitting, setReplySubmitting] = useState(false);
+
+    const fetchPost = useCallback(async () => {
+        try {
+            setLoading(true);
+            setErr("");
+
+            const res = await fetch(
+                `${API_BASE}/community/${communityId}/posts/${postId}`,
+                { credentials: "include" }
+            );
+            const data = await res.json().catch(() => ({}));
+
+            if (!res.ok || !data.ok) {
+                throw new Error(data.error || "Failed to load post.");
+            }
+
+            setPost(data.post);
+            setCommunity(data.community || null);
+            setPollResults(data.post.pollResults || null);
+            setMyVotes(data.post.myVotes || []);
+        } catch (error) {
+            console.error("[PostDetail] fetchPost error:", error);
+            setErr(error.message || "Unable to load this post.");
+        } finally {
+            setLoading(false);
+        }
+    }, [communityId, postId]);
+
+    const fetchReplies = useCallback(async () => {
+        try {
+            setRepliesLoading(true);
+            setReplyError("");
+
+            const res = await fetch(
+                `${API_BASE}/community/${communityId}/posts/${postId}/replies`,
+                { credentials: "include" }
+            );
+            const data = await res.json().catch(() => ({}));
+
+            if (!res.ok || !data.ok) {
+                throw new Error(data.error || "Failed to load replies.");
+            }
+
+            setReplies(data.replies || []);
+        } catch (error) {
+            console.error("[PostDetail] fetchReplies error:", error);
+            setReplyError(error.message || "Unable to load replies.");
+        } finally {
+            setRepliesLoading(false);
+        }
+    }, [communityId, postId]);
+
+    useEffect(() => {
+        fetchPost();
+        fetchReplies();
+    }, [fetchPost, fetchReplies]);
+
+    const handleVote = async (optionIndex) => {
+        if (!post || post.type !== "poll") return;
+        setVoting(true);
+        setVoteError("");
+
+        try {
+            const res = await fetch(
+                `${API_BASE}/community/${communityId}/posts/${post.id}/vote`,
+                {
+                    method: "POST",
+                    credentials: "include",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ optionIndex }),
+                }
+            );
+
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok || !data.ok) {
+                throw new Error(data.error || "Failed to submit vote.");
+            }
+
+            setPollResults(data.pollResults || null);
+            setMyVotes(data.myVotes || []);
+        } catch (error) {
+            console.error("[PostDetail] vote error:", error);
+            setVoteError(error.message || "Could not submit your vote.");
+        } finally {
+            setVoting(false);
+        }
+    };
+
+    const handleSubmitReply = async (e) => {
+        e.preventDefault();
+        if (!replyBody.trim()) return;
+
+        setReplySubmitting(true);
+        setReplyError("");
+
+        try {
+            const res = await fetch(
+                `${API_BASE}/community/${communityId}/posts/${postId}/replies`,
+                {
+                    method: "POST",
+                    credentials: "include",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ body: replyBody }),
+                }
+            );
+
+            const data = await res.json().catch(() => ({}));
+
+            if (!res.ok || !data.ok) {
+                throw new Error(data.error || "Failed to post reply.");
+            }
+
+            setReplyBody("");
+            await fetchReplies();
+            // Optionally refresh post too to update replyCount
+            fetchPost();
+        } catch (error) {
+            console.error("[PostDetail] submitReply error:", error);
+            setReplyError(error.message || "Unable to post reply.");
+        } finally {
+            setReplySubmitting(false);
+        }
+    };
+
+    const handleBackClick = () => {
+        navigate(`/community/${communityId}/my-posts`);
+    };
+
+    if (loading) {
+        return (
+            <section className="ForumContainer">
+                <div className="ForumHero ForumHero--small">
+                    <PageHeader />
+                </div>
+                <section className="ForumBody">
+                    <p>Loading post…</p>
+                </section>
+                <Footer />
+            </section>
+        );
+    }
+
+    if (err || !post) {
+        return (
+            <section className="ForumContainer">
+                <div className="ForumHero ForumHero--small">
+                    <PageHeader />
+                </div>
+                <section className="ForumBody">
+                    <p className="communityError">
+                        {err || "Post not found."}
+                    </p>
+                    <button className="NewPostSecondaryButton" onClick={handleBackClick}>
+                        Back to community
+                    </button>
+                </section>
+                <Footer />
+            </section>
+        );
+    }
+
+    const {
+        title,
+        body,
+        type,
+        replyCount,
+        createdAt,
+        updatedAt,
+        author,
+        poll,
+    } = post;
+
+    const typeLabel =
+        type === "questions"
+            ? "Questions"
+            : type === "announcements"
+                ? "Announcements"
+                : type === "poll"
+                    ? "Poll"
+                    : "General";
+
+    const activityText = Time(updatedAt || createdAt);
+
+    const renderPollSection = () => {
+        if (!post.poll || !post.poll.options?.length) {
+            return (
+                <p className="PostDetailEmptyPoll">
+                    This poll doesn’t have any options yet.
+                </p>
+            );
+        }
+
+        const counts = pollResults?.counts || [];
+        const totalVotes = pollResults?.totalVotes || 0;
+
+        return (
+            <div className="PostDetailPoll">
+                <h3 className="PostDetailSubTitle">Poll options</h3>
+                <ul className="PostDetailPollList">
+                    {post.poll.options.map((opt, idx) => {
+                        const count = counts[idx] || 0;
+                        const percentage =
+                            totalVotes > 0 ? Math.round((count / totalVotes) * 100) : 0;
+                        const isSelected = myVotes.includes(idx);
+
+                        return (
+                            <li key={idx} className="PostDetailPollOption">
+                                <button
+                                    type="button"
+                                    className={`PostDetailPollButton ${isSelected ? "selected" : ""
+                                        }`}
+                                    disabled={voting}
+                                    onClick={() => handleVote(idx)}
+                                >
+                                    <span className="PostDetailPollLabel">{opt.text}</span>
+                                    {totalVotes > 0 && (
+                                        <span className="PostDetailPollStats">
+                                            {count} vote{count === 1 ? "" : "s"} ({percentage}%)
+                                        </span>
+                                    )}
+                                </button>
+                            </li>
+                        );
+                    })}
+                </ul>
+
+                <p className="PostDetailPollMeta">
+                    {post.poll.allowMultiple
+                        ? "You can vote for more than one option."
+                        : "You can vote for one option."}{" "}
+                    {post.poll.anonymous
+                        ? "Votes are anonymous."
+                        : "Votes may be visible per user."}
+                </p>
+
+                {voteError && (
+                    <p className="communityError smallError">{voteError}</p>
+                )}
+            </div>
+        );
+    };
+
+
+    return (
+        <section className="ForumContainer">
+            <div className="ForumHero ForumHero--small">
+                <PageHeader />
+                <div className="ForumHeaderContainer">
+                    <h1 className="ForumHeader">{community?.header || "Community"}</h1>
+                    <h2 className="ForumSubHeader">
+                        <Link
+                            to={`/community/${communityId}/my-posts`}
+                            className="PostDetailBreadcrumb"
+                        >
+                            Back to posts
+                        </Link>
+                    </h2>
+                </div>
+            </div>
+
+            <section className="ForumBody PostDetailBody">
+                <header className="PostDetailHeader">
+                    <div className="PostDetailMetaRow">
+                        <span className={`Tag ${type || "general"}`}>
+                            {type === "poll" ? "📊 Poll" : typeLabel}
+                        </span>
+                        <span className="PostDetailMetaText">
+                            Posted by {author || "Unknown"} · {activityText}
+                        </span>
+                    </div>
+
+                    <h1 className="PostDetailTitle">{title}</h1>
+                </header>
+
+                {type === "poll" && renderPollSection()}
+
+                {body && (
+                    <article className="PostDetailContent">
+                        <p>{body}</p>
+                    </article>
+                )}
+
+                <section className="PostDetailReplies">
+                    <h2 className="PostDetailSubTitle">
+                        Replies ({post.replyCount ?? replies.length})
+                    </h2>
+
+                    {replyError && (
+                        <p className="communityError smallError">{replyError}</p>
+                    )}
+
+                    {repliesLoading ? (
+                        <p>Loading replies…</p>
+                    ) : replies.length === 0 ? (
+                        <p className="PostDetailRepliesEmpty">
+                            No replies yet. Be the first to respond.
+                        </p>
+                    ) : (
+                        <ul className="PostDetailRepliesList">
+                            {replies.map((r) => (
+                                <li key={r.id} className="PostDetailReplyItem">
+                                    <div className="PostDetailReplyHeader">
+                                        <span className="PostDetailReplyAuthor">
+                                            {r.author || "Unknown"}
+                                        </span>
+                                        <span className="PostDetailReplyTime">
+                                            {Time(r.createdAt)}
+                                        </span>
+                                    </div>
+                                    <p className="PostDetailReplyBody">{r.body}</p>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+
+                    <form className="PostDetailReplyForm" onSubmit={handleSubmitReply}>
+                        <label htmlFor="reply-body" className="PostDetailSubTitle">
+                            Add a reply
+                        </label>
+                        <textarea
+                            id="reply-body"
+                            rows={3}
+                            value={replyBody}
+                            onChange={(e) => setReplyBody(e.target.value)}
+                            placeholder="Share your thoughts or encouragement…"
+                            disabled={replySubmitting}
+                        />
+                        <button
+                            type="submit"
+                            className="NewPostPrimaryButton"
+                            disabled={replySubmitting || !replyBody.trim()}
+                        >
+                            {replySubmitting ? "Posting…" : "Post reply"}
+                        </button>
+                    </form>
+                </section>
+            </section>
+
+            <Footer />
+        </section>
+    );
+};
+
+export default PostDetail;


### PR DESCRIPTION
feat(community): add poll posts, post detail view, and hero hero uploads

- Add dedicated PostDetail page with full post view, activity meta, and breadcrumb back to community posts
- Support poll-type posts end-to-end: render poll options, show aggregated results, and allow single/multi-option voting with myVotes state
- Implement replies for posts: load replies list, show timestamps, and allow authenticated users to submit new replies with validation and error states
- Wire /community/:communityId/posts/:postId route in App and make forum table rows in MyCommunity navigable to the post detail page
- Extend Community schema with heroImageUrl and serve uploaded assets from /uploads via Express static middleware
- Add Multer-based hero image upload endpoint (/community/:id/hero-image) and store per-community hero background files under uploads/community-heroes
- Update MyCommunity hero section to use custom heroImageUrl when available, with a default fallback image
- Add small hover upload control with + button over the hero image, restricted to Owner/Leader based on membership, with loading and error feedback
- Introduce CommunityPollVote model and poll aggregation logic to count votes, compute totals, and return per-user selections
- Relax CommunityPost body requirement for poll posts and guard subtitle/body handling to avoid crashes when body is empty
- Fix PostDetail hooks by defining fetchPost/fetchReplies with useCallback before useEffect and removing duplicate fetch calls
- Improve CommunityBody grid + “Show More” logic to base visible counts on computed grid-template-columns and cap discover list at MAX_DISCOVER_VISIBLE
