### PR TITLE
Add verse-range notes flow with inline verse pairing

### DIFF
--- a/src/pages/Study/Bible.js
+++ b/src/pages/Study/Bible.js
@@ -6,84 +6,59 @@ import Verse from "./verseDisplay/Verse";
 
 // Static chapter counts for Korean ibibles.net mapping
 const KOR_CHAPTER_COUNTS = {
-  ge: 50,
-  exo: 40,
-  lev: 27,
-  num: 36,
-  deu: 34,
-  josh: 24,
-  jdgs: 21,
-  ruth: 4,
-  "1sm": 31,
-  "2sm": 24,
-  "1ki": 22,
-  "2ki": 25,
-  "1chr": 29,
-  "2chr": 36,
-  ezra: 10,
-  neh: 13,
-  est: 10,
-  job: 42,
-  psa: 150,
-  prv: 31,
-  eccl: 12,
-  ssol: 8,
-  isa: 66,
-  jer: 52,
-  lam: 5,
-  eze: 48,
-  dan: 12,
-  hos: 14,
-  joel: 3,
-  amos: 9,
-  obad: 1,
-  jonah: 4,
-  mic: 7,
-  nahum: 3,
-  hab: 3,
-  zep: 3,
-  hag: 2,
-  zec: 14,
-  mal: 4,
-  mat: 28,
-  mark: 16,
-  luke: 24,
-  john: 21,
-  acts: 28,
-  rom: 16,
-  "1cor": 16,
-  "2cor": 13,
-  gal: 6,
-  eph: 6,
-  phi: 4,
-  col: 4,
-  "1th": 5,
-  "2th": 3,
-  "1tim": 6,
-  "2tim": 4,
-  titus: 3,
-  phmn: 1,
-  heb: 13,
-  jas: 5,
-  "1pet": 5,
-  "2pet": 3,
-  "1jn": 5,
-  "2jn": 1,
-  "3jn": 1,
-  jude: 1,
-  rev: 22,
+  ge: 50, exo: 40, lev: 27, num: 36, deu: 34,
+  josh: 24, jdgs: 21, ruth: 4, "1sm": 31, "2sm": 24,
+  "1ki": 22, "2ki": 25, "1chr": 29, "2chr": 36,
+  ezra: 10, neh: 13, est: 10, job: 42, psa: 150,
+  prv: 31, eccl: 12, ssol: 8, isa: 66, jer: 52,
+  lam: 5, eze: 48, dan: 12, hos: 14, joel: 3,
+  amos: 9, obad: 1, jonah: 4, mic: 7, nahum: 3,
+  hab: 3, zep: 3, hag: 2, zec: 14, mal: 4,
+  mat: 28, mark: 16, luke: 24, john: 21, acts: 28,
+  rom: 16, "1cor": 16, "2cor": 13, gal: 6, eph: 6,
+  phi: 4, col: 4, "1th": 5, "2th": 3, "1tim": 6,
+  "2tim": 4, titus: 3, phmn: 1, heb: 13, jas: 5,
+  "1pet": 5, "2pet": 3, "1jn": 5, "2jn": 1, "3jn": 1,
+  jude: 1, rev: 22,
 };
 
 const Bible = () => {
-  const [currChapterId, setCurrentChapterId] = useState(null); // e.g. "gen.1"
+  const [currChapterId, setCurrentChapterId] = useState(null);
   const [currBook, setCurrBook] = useState({ id: null, name: "" });
-  const [currVersion, setCurrVersion] = useState("06125adad2d5898a-01"); // default ASV
+  const [currVersion, setCurrVersion] = useState("06125adad2d5898a-01"); // ASV default
 
-  // Ordered list of books for current version: [{ id, name }]
   const [booksOrder, setBooksOrder] = useState([]);
-
-  // Cache of chapters per book: { [bookId]: [{ id, number }] }
   const [chaptersByBook, setChaptersByBook] = useState({});
+
+  // --- Notes feature state ---
+  const [isNotesOpen, setIsNotesOpen] = useState(false);
+
+  // { [chapterId]: { title: string, text: string } }
+  const [notesByChapter, setNotesByChapter] = useState({});
+
+  const getChapterNote = useCallback(
+    (chapterId) => {
+      const entry = chapterId ? notesByChapter[chapterId] : null;
+      return {
+        title: entry?.title || "",
+        text: entry?.text || "",
+      };
+    },
+    [notesByChapter]
+  );
+
+  const saveChapterNote = useCallback((chapterId, payload) => {
+    if (!chapterId) return;
+
+    const nextTitle = (payload?.title ?? "").toString();
+    const nextText = (payload?.text ?? "").toString();
+
+    setNotesByChapter((prev) => ({
+      ...prev,
+      [chapterId]: { title: nextTitle, text: nextText },
+    }));
+  }, []);
+
 
   // ---- Load books when version changes ----
   useEffect(() => {
@@ -91,10 +66,8 @@ const Bible = () => {
 
     (async () => {
       try {
-        const books = await GetBookVersions(currVersion); // returns KOR_BOOKS for "kor"
-        if (!cancelled) {
-          setBooksOrder(books || []);
-        }
+        const books = await GetBookVersions(currVersion);
+        if (!cancelled) setBooksOrder(books || []);
       } catch (e) {
         if (!cancelled) {
           console.error("Failed to load books for version", currVersion, e);
@@ -103,10 +76,10 @@ const Bible = () => {
       }
     })();
 
-    // clear chapter cache when version changes
     setChaptersByBook({});
     setCurrBook({ id: null, name: "" });
     setCurrentChapterId(null);
+    setIsNotesOpen(false);
 
     return () => {
       cancelled = true;
@@ -118,12 +91,8 @@ const Bible = () => {
     async (bookId) => {
       if (!bookId) return [];
 
-      // If we already have them cached, reuse
-      if (chaptersByBook[bookId]) {
-        return chaptersByBook[bookId];
-      }
+      if (chaptersByBook[bookId]) return chaptersByBook[bookId];
 
-      // KOREAN: use static chapter counts
       if (currVersion === "kor") {
         const count = KOR_CHAPTER_COUNTS[bookId] || 0;
         const list = Array.from({ length: count }, (_, i) => ({
@@ -131,15 +100,10 @@ const Bible = () => {
           id: `${bookId}.${i + 1}`,
         }));
 
-        setChaptersByBook((prev) => ({
-          ...prev,
-          [bookId]: list,
-        }));
-
+        setChaptersByBook((prev) => ({ ...prev, [bookId]: list }));
         return list;
       }
 
-      // Other versions: use api.scripture.api.bible
       const url = `https://api.scripture.api.bible/v1/bibles/${currVersion}/books/${bookId}/chapters`;
 
       try {
@@ -149,16 +113,9 @@ const Bible = () => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
 
         const { data } = await res.json();
-        const arr = (data || []).map(({ id, number }) => ({
-          id,
-          number,
-        }));
+        const arr = (data || []).map(({ id, number }) => ({ id, number }));
 
-        setChaptersByBook((prev) => ({
-          ...prev,
-          [bookId]: arr,
-        }));
-
+        setChaptersByBook((prev) => ({ ...prev, [bookId]: arr }));
         return arr;
       } catch (e) {
         console.error("Failed to load chapters", { bookId, currVersion }, e);
@@ -168,32 +125,25 @@ const Bible = () => {
     [currVersion, chaptersByBook]
   );
 
-  // Ensure current book's chapters are loaded when book changes
   useEffect(() => {
-    if (currBook?.id) {
-      fetchChapters(currBook.id);
-    }
+    if (currBook?.id) fetchChapters(currBook.id);
   }, [currBook?.id, fetchChapters]);
 
-  // Current book's chapter list
   const currChapters = useMemo(() => {
     if (!currBook?.id) return [];
     return chaptersByBook[currBook.id] || [];
   }, [chaptersByBook, currBook?.id]);
 
-  // Index of current chapter in that list
   const currChapterIndex = useMemo(() => {
     if (!currChapterId || !currChapters.length) return -1;
     return currChapters.findIndex((c) => c.id === currChapterId);
   }, [currChapters, currChapterId]);
 
-  // Find book index in booksOrder
   const getBookIndex = useCallback(
     (bookId) => booksOrder.findIndex((b) => b.id === bookId),
     [booksOrder]
   );
 
-  // Jump helpers
   const goToFirstChapterOf = useCallback(
     async (bookObj) => {
       const list = await fetchChapters(bookObj.id);
@@ -216,26 +166,19 @@ const Bible = () => {
     [fetchChapters]
   );
 
-  // ---- Navigation: Next chapter / book ----
   const goNextChapter = useCallback(async () => {
-    if (!currBook?.id) return;
+    if (!currBook?.id || isNotesOpen) return;
 
-    // 1) Next chapter in same book
-    if (
-      currChapterIndex >= 0 &&
-      currChapterIndex < currChapters.length - 1
-    ) {
+    if (currChapterIndex >= 0 && currChapterIndex < currChapters.length - 1) {
       setCurrentChapterId(currChapters[currChapterIndex + 1].id);
       return;
     }
 
-    // 2) We're at last chapter of this book → go to first chapter of next book
     const bi = getBookIndex(currBook.id);
     if (bi >= 0 && bi < booksOrder.length - 1) {
       const nextBook = booksOrder[bi + 1];
       await goToFirstChapterOf(nextBook);
     }
-    // If bi is last index or -1 → no next book → do nothing
   }, [
     currBook,
     currChapters,
@@ -243,25 +186,22 @@ const Bible = () => {
     booksOrder,
     getBookIndex,
     goToFirstChapterOf,
+    isNotesOpen,
   ]);
 
-  // ---- Navigation: Previous chapter / book ----
   const goPrevChapter = useCallback(async () => {
-    if (!currBook?.id) return;
+    if (!currBook?.id || isNotesOpen) return;
 
-    // 1) Previous chapter in same book
     if (currChapterIndex > 0) {
       setCurrentChapterId(currChapters[currChapterIndex - 1].id);
       return;
     }
 
-    // 2) We're at first chapter → go to last chapter of previous book
     const bi = getBookIndex(currBook.id);
     if (bi > 0) {
       const prevBook = booksOrder[bi - 1];
       await goToLastChapterOf(prevBook);
     }
-    // If bi <= 0 → no previous book
   }, [
     currBook,
     currChapters,
@@ -269,21 +209,20 @@ const Bible = () => {
     booksOrder,
     getBookIndex,
     goToLastChapterOf,
+    isNotesOpen,
   ]);
 
-  // ---- Arrow visibility ----
   const canPrev = useMemo(() => {
-    if (!currBook?.id) return false;
+    if (!currBook?.id || isNotesOpen) return false;
     const bi = getBookIndex(currBook.id);
     return currChapterIndex > 0 || bi > 0;
-  }, [currBook?.id, currChapterIndex, getBookIndex]);
+  }, [currBook?.id, currChapterIndex, getBookIndex, isNotesOpen]);
 
   const canNext = useMemo(() => {
-    if (!currBook?.id) return false;
+    if (!currBook?.id || isNotesOpen) return false;
     const bi = getBookIndex(currBook.id);
     return (
-      (currChapterIndex >= 0 &&
-        currChapterIndex < currChapters.length - 1) ||
+      (currChapterIndex >= 0 && currChapterIndex < currChapters.length - 1) ||
       bi < booksOrder.length - 1
     );
   }, [
@@ -292,27 +231,27 @@ const Bible = () => {
     currChapters.length,
     getBookIndex,
     booksOrder.length,
+    isNotesOpen,
   ]);
 
   return (
     <section className="ReadBible">
       <BibleVersion
+        disabled={isNotesOpen}
         setChapter={setCurrentChapterId}
         book={currBook}
         setBook={(b) => {
-          // selecting a new book from modal
           if (!b) {
             setCurrBook({ id: null, name: "" });
             setCurrentChapterId(null);
             return;
           }
           setCurrBook(b);
-          setCurrentChapterId(null); // wait for chapter selection
+          setCurrentChapterId(null);
         }}
         currVersionId={currVersion}
         setCurrentVersion={(v) => {
           setCurrVersion(v);
-          // booksOrder + chaptersByBook are reset in the useEffect above
         }}
       />
 
@@ -324,6 +263,11 @@ const Bible = () => {
         onNext={goNextChapter}
         canPrev={canPrev}
         canNext={canNext}
+        // notes props
+        isNotesOpen={isNotesOpen}
+        setIsNotesOpen={setIsNotesOpen}
+        getChapterNote={getChapterNote}
+        saveChapterNote={saveChapterNote}
       />
     </section>
   );

--- a/src/pages/Study/bibleVersions/BibleVersions.css
+++ b/src/pages/Study/bibleVersions/BibleVersions.css
@@ -26,6 +26,17 @@
     cursor: pointer;
 }
 
+.BookVersionHolder.isDisabled {
+  opacity: 0.65;
+}
+
+.BookTabContainer.disabled,
+.VersionTabContainer.disabled {
+  pointer-events: none;
+  cursor: not-allowed;
+}
+
+
 /* .Books:hover, .Versions:hover {
     border: 1px black solid;
     border-bottom: none;

--- a/src/pages/Study/bibleVersions/BibleVersions.js
+++ b/src/pages/Study/bibleVersions/BibleVersions.js
@@ -1,70 +1,87 @@
-import './BibleVersions.css';
+import "./BibleVersions.css";
 import { GoTriangleDown } from "react-icons/go";
-import { useState } from 'react';
-import BibleVersionComponent from './BibleVersionComponent';
-import BookVersionModal from '../bookVersions/BookVersionModal';
+import { useState } from "react";
+import BibleVersionComponent from "./BibleVersionComponent";
+import BookVersionModal from "../bookVersions/BookVersionModal";
 
 const BibleVersions = ({
+  disabled = false,
   setChapter,
   book,
   setBook,
   currVersionId,
-  setCurrentVersion
+  setCurrentVersion,
 }) => {
   const [bookModal, setVisibility] = useState(false);
   const [versionModal, setVersionVisibility] = useState(false);
-  const [versionLabel, setVersionLabel] = useState("ASV"); // display only
+  const [versionLabel, setVersionLabel] = useState("ASV");
+
+  // If we become disabled while a modal is open, close them
+  if (disabled && (bookModal || versionModal)) {
+    // safe immediate close
+    if (bookModal) setVisibility(false);
+    if (versionModal) setVersionVisibility(false);
+  }
+
+  const guardClick = (fn) => {
+    if (disabled) return;
+    fn?.();
+  };
 
   return (
-    <div className="BookVersionHolder">
+    <div className={`BookVersionHolder ${disabled ? "isDisabled" : ""}`}>
       {/* Book selector */}
       <div className="Books">
         <section
-          className='BookTabContainer'
-          onClick={() => setVisibility(!bookModal)}
+          className={`BookTabContainer ${disabled ? "disabled" : ""}`}
+          onClick={() => guardClick(() => setVisibility(!bookModal))}
+          aria-disabled={disabled ? "true" : "false"}
+          title={disabled ? "Close notes to change book/chapter" : undefined}
         >
           <p className="BookNameDisplay">{book?.name || "Select a Book"}</p>
           <GoTriangleDown className="BookVersionDownArrow" />
         </section>
 
-        <BookVersionModal
-          key={currVersionId} // remount when version changes
-          setVis={setVisibility}
-          visibilityStatus={bookModal}
-          versionId={currVersionId}
-          onBookSelect={(b) => {
-            setBook(b);
-            setChapter(null);
-          }}
-          onChapterSelect={setChapter}
-          currentBookId={book?.id}
-        />
+        {!disabled && (
+          <BookVersionModal
+            key={currVersionId}
+            setVis={setVisibility}
+            visibilityStatus={bookModal}
+            versionId={currVersionId}
+            onBookSelect={(b) => {
+              setBook(b);
+              setChapter(null);
+            }}
+            onChapterSelect={setChapter}
+            currentBookId={book?.id}
+          />
+        )}
       </div>
 
       {/* Version selector */}
       <div className="Versions">
         <section
-          className='VersionTabContainer'
-          onClick={() => setVersionVisibility(!versionModal)}
+          className={`VersionTabContainer ${disabled ? "disabled" : ""}`}
+          onClick={() => guardClick(() => setVersionVisibility(!versionModal))}
+          aria-disabled={disabled ? "true" : "false"}
+          title={disabled ? "Close notes to change version" : undefined}
         >
           <p className="VersionNameDisplay">{versionLabel}</p>
           <GoTriangleDown className="BookVersionDownArrow" />
         </section>
 
-        <BibleVersionComponent
-          setVis={setVersionVisibility}
-          visibilityStatus={versionModal}
-          // called with abbreviation (ASV, BSB, engKJV, WEB, FBV, KOR)
-          versionChange={(abbr) => {
-            setVersionLabel(abbr);
-          }}
-          // called with underlying id (api.bible id or "kor")
-          setCurrentVersionId={(newVersionId) => {
-            setCurrentVersion(newVersionId);
-            setBook({ id: null, name: "" });
-            setChapter(null);
-          }}
-        />
+        {!disabled && (
+          <BibleVersionComponent
+            setVis={setVersionVisibility}
+            visibilityStatus={versionModal}
+            versionChange={(abbr) => setVersionLabel(abbr)}
+            setCurrentVersionId={(newVersionId) => {
+              setCurrentVersion(newVersionId);
+              setBook({ id: null, name: "" });
+              setChapter(null);
+            }}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/pages/Study/verseDisplay/Verse.css
+++ b/src/pages/Study/verseDisplay/Verse.css
@@ -26,6 +26,111 @@
   color: #333;
 }
 
+.chapterTitleButton {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  width: 100%;
+  text-align: center;
+  /* centers text */
+}
+
+.chapterTitleButton.active {
+  text-decoration: underline;
+}
+
+/* Notes shell: 35% of viewport height */
+.chapterNotesShell {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin: 12px 0 16px;
+}
+
+.chapterNotesInner {
+  height: 35vh;
+  width: 80vw;
+  max-width: 1280px;
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 14px;
+  padding: 14px 14px 12px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  backdrop-filter: blur(8px);
+}
+
+.chapterNotesHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.chapterNotesTitle {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.chapterNotesActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.notesBtn {
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 12px;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.notesBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.notesBtnGhost {
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.notesBtnPrimary {
+  background: rgba(0, 0, 0, 0.85);
+  color: white;
+}
+
+.notesLoginPrompt {
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.06);
+  font-size: 14px;
+}
+
+.chapterNotesTextarea {
+  width: 100%;
+  flex: 1;
+  resize: none;
+  border-radius: 12px;
+  padding: 12px;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  outline: none;
+  font-size: 14px;
+  line-height: 1.4;
+  background: rgba(255, 255, 255, 0.85);
+  box-sizing: border-box;
+}
+
+.chapterNotesTextarea:disabled {
+  background: rgba(255, 255, 255, 0.55);
+}
+
+
 .chapterTitle.placeholder {
   color: #aaa;
   font-style: italic;
@@ -55,23 +160,57 @@
 /* Each row = up to 2 verses */
 .verseRowPair {
   padding-bottom: 12px;
+  display: block;
+  line-height: 1.6;
+  margin-bottom: 10px;
+}
+
+/* Buttons must be inline, not block, not flex */
+.verseInlineBtn {
+  display: inline;
+  width: auto;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+/* Nice subtle hover without changing layout */
+.verseInlineBtn:hover {
+  text-decoration: underline;
+}
+
+/* The separator between two verses in a pair */
+.verseJoiner {
+  display: inline;
 }
 
 /* Container for each single verse inside the pair */
 .verseChunk {
   display: inline;
-  /* seamless flow */
   margin-right: 10px;
-  /* small gap between verse pairs */
 }
 
 /* Visual for the numbers we render in JSX */
 .verseNum {
   font-size: 0.65rem;
-  vertical-align: top;
+  vertical-align: super;
   margin-right: 3px;
   color: #888;
   font-weight: 600;
+}
+
+/* IMPORTANT: don't introduce forced breaks */
+.verseText {
+  white-space: normal;
+}
+
+.verseGap {
+  display: inline;
 }
 
 .versesList li::before {
@@ -124,6 +263,297 @@
 .navArrow[disabled] {
   display: none;
 }
+
+/* --- Bottom fixed notes editor --- */
+.chapterNotesShell {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+
+  display: flex;
+  justify-content: center;
+
+  padding: 12px 12px calc(12px + env(safe-area-inset-bottom));
+  z-index: 9999;
+
+  /* subtle overlay so it feels “active” */
+  background: linear-gradient(to top,
+      rgba(0, 0, 0, 0.20),
+      rgba(0, 0, 0, 0.00));
+}
+
+.chapterNotesInner {
+  height: 35vh;
+  width: 80vw;
+  max-width: 1280px;
+
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 16px 16px 0 0;
+  padding: 14px 14px 12px;
+  box-sizing: border-box;
+
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  box-shadow: 0 -10px 30px rgba(0, 0, 0, 0.18);
+  backdrop-filter: blur(10px);
+}
+
+.chapterNotesHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.chapterNotesTitle {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.chapterNotesActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.notesBtn {
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 12px;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.notesBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.notesBtnGhost {
+  background: rgba(255, 255, 255, 0.75);
+}
+
+.notesBtnPrimary {
+  background: rgba(0, 0, 0, 0.88);
+  color: white;
+}
+
+.notesLoginPrompt {
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.06);
+  font-size: 14px;
+}
+
+.chapterNotesTextarea {
+  width: 100%;
+  flex: 1;
+  resize: none;
+
+  border-radius: 12px;
+  padding: 12px;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  outline: none;
+
+  font-size: 14px;
+  line-height: 1.4;
+
+  background: rgba(255, 255, 255, 0.95);
+  box-sizing: border-box;
+}
+
+.chapterNotesTextarea:disabled {
+  background: rgba(255, 255, 255, 0.65);
+}
+
+.DisplaySection.notesOpen {
+  /* give space roughly equal to the bottom sheet height */
+  padding-bottom: 15vh;
+}
+
+
+.chapterNotesTitleInput {
+  width: 100%;
+  max-width: 720px;
+
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 12px;
+
+  padding: 8px 10px;
+  font-size: 15px;
+  font-weight: 600;
+
+  background: rgba(255, 255, 255, 0.85);
+  outline: none;
+}
+
+.chapterNotesTitleInput:focus {
+  border-color: rgba(0, 0, 0, 0.35);
+}
+
+.chapterNotesTitleInput:disabled {
+  opacity: 0.7;
+}
+
+/* Header row so "Clear range" can sit beside chapter title */
+.chapterHeaderRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.clearRangeBtn {
+  border: 1px solid rgba(0, 0, 0, 0.14);
+  background: rgba(255, 255, 255, 0.75);
+  border-radius: 12px;
+  padding: 8px 10px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.clearRangeBtn:hover {
+  background: rgba(255, 255, 255, 0.95);
+}
+
+/* Make verseChunk clickable as a button without ugly default button UI */
+.verseChunkBtn {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.verseChunkBtn:hover {
+  text-decoration: underline;
+}
+
+/* ------- Range modal ------- */
+.rangeModalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+}
+
+.rangeModalCard {
+  width: min(720px, 92vw);
+  background: rgba(255, 255, 255, 0.96);
+  border-radius: 16px;
+  padding: 14px;
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(10px);
+}
+
+.rangeModalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.rangeModalTitle {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.rangeModalClose {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 12px;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.rangeModalBody {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 10px 0 6px;
+}
+
+.rangeRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.rangeLabel {
+  font-size: 14px;
+  font-weight: 600;
+  opacity: 0.85;
+}
+
+.rangeSelect {
+  width: 180px;
+  max-width: 55vw;
+  border: 1px solid rgba(0, 0, 0, 0.14);
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.rangeHint {
+  font-size: 13px;
+  opacity: 0.75;
+}
+
+.rangeModalFooter {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding-top: 10px;
+}
+
+.rangeBtn {
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 12px;
+  padding: 10px 12px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.rangeBtnGhost {
+  background: rgba(255, 255, 255, 0.75);
+}
+
+.rangeBtnPrimary {
+  background: rgba(0, 0, 0, 0.9);
+  color: white;
+}
+
+/* When notes bottom-sheet is open, keep content scrollable above it */
+.DisplaySection.notesOpen {
+  padding-bottom: 40vh;
+}
+
+.chapterHeaderStack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  /* centers title */
+  gap: 6px;
+}
+
+/* Clear button row aligned to right, while title stays centered */
+.clearRangeRow {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+}
+
 
 /* Small screens: bring arrows closer to edges and make them slightly smaller */
 @media (max-width: 768px) {

--- a/src/pages/Study/verseDisplay/Verse.js
+++ b/src/pages/Study/verseDisplay/Verse.js
@@ -1,6 +1,7 @@
 import "./Verse.css";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import API from "../../../component/Key";
+import { useAuth } from "../../../component/context/AuthContext";
 
 const Verse = ({
   chapterId,
@@ -10,13 +11,36 @@ const Verse = ({
   onNext,
   canPrev,
   canNext,
+
+  // notes props (from Bible.jsx)
+  isNotesOpen,
+  setIsNotesOpen,
+  getChapterNote,
+  saveChapterNote,
 }) => {
+  const { user, initializing } = useAuth();
+
   const [verses, setVerses] = useState([]);
   const [verseTexts, setVerseTexts] = useState({});
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
 
+  // Notes drafts (keep whatever you currently use)
+  const [noteDraft, setNoteDraft] = useState("");
+  const [noteTitleDraft, setNoteTitleDraft] = useState("");
+
+  // -------- NEW: Verse range selection --------
+  // activeRange: { start: number, end: number } OR null (means show whole chapter)
+  const [activeRange, setActiveRange] = useState(null);
+
+  // range modal state
+  const [rangeModalOpen, setRangeModalOpen] = useState(false);
+  const [rangeStart, setRangeStart] = useState(null);
+  const [rangeEnd, setRangeEnd] = useState(null);
+  const [rangeAnchor, setRangeAnchor] = useState(null); // clicked verse number
+
   const hasChapter = !!chapterId;
+  const chapterNumber = hasChapter ? (chapterId.split(".")[1] || "") : "";
 
   // Fetch verses whenever version or chapter changes
   useEffect(() => {
@@ -31,12 +55,19 @@ const Verse = ({
         setVerseTexts({});
         setLoading(true);
 
+        // reset selection when chapter changes
+        setActiveRange(null);
+        setRangeModalOpen(false);
+        setRangeStart(null);
+        setRangeEnd(null);
+        setRangeAnchor(null);
+        setIsNotesOpen?.(false);
+
         // ---------- KOREAN ----------
         if (currVersionId === "kor") {
-          const res = await fetch(
-            `/api/passage/${currVersionId}/${chapterId}`,
-            { signal: controller.signal }
-          );
+          const res = await fetch(`/api/passage/${currVersionId}/${chapterId}`, {
+            signal: controller.signal,
+          });
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
 
           const data = await res.json();
@@ -48,17 +79,8 @@ const Verse = ({
             text: (v.text || "").toString().trim(),
           }));
 
-          setVerses(
-            normalized.map((v) => ({
-              id: v.id,
-              number: v.number,
-            }))
-          );
-
-          setVerseTexts(
-            Object.fromEntries(normalized.map((v) => [v.id, v.text]))
-          );
-
+          setVerses(normalized.map((v) => ({ id: v.id, number: v.number })));
+          setVerseTexts(Object.fromEntries(normalized.map((v) => [v.id, v.text])));
           return;
         }
 
@@ -71,10 +93,7 @@ const Verse = ({
         url.searchParams.set("include-verse-spans", "true");
 
         const res = await fetch(url.toString(), {
-          headers: {
-            "api-key": API,
-            accept: "application/json",
-          },
+          headers: { "api-key": API, accept: "application/json" },
           signal: controller.signal,
         });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -84,23 +103,16 @@ const Verse = ({
 
         const withNumbers = raw.map((v, index) => {
           let num = index + 1;
-
           if (v.reference) {
             const parts = v.reference.split(":");
             const last = parts[parts.length - 1];
             const parsed = parseInt(last, 10);
             if (!isNaN(parsed)) num = parsed;
           }
-
           return { ...v, number: num };
         });
 
-        setVerses(
-          withNumbers.map((v) => ({
-            id: v.id,
-            number: v.number,
-          }))
-        );
+        setVerses(withNumbers.map((v) => ({ id: v.id, number: v.number })));
 
         const entries = await Promise.all(
           withNumbers.map(async (v) => {
@@ -113,19 +125,13 @@ const Verse = ({
             vUrl.searchParams.set("include-titles", "false");
 
             const r = await fetch(vUrl.toString(), {
-              headers: {
-                "api-key": API,
-                accept: "application/json",
-              },
+              headers: { "api-key": API, accept: "application/json" },
               signal: controller.signal,
             });
             if (!r.ok) throw new Error(`HTTP ${r.status}`);
 
             const { data } = await r.json();
-            const text = (data?.text ?? data?.content ?? "")
-              .toString()
-              .trim();
-
+            const text = (data?.text ?? data?.content ?? "").toString().trim();
             return [v.id, text];
           })
         );
@@ -142,9 +148,80 @@ const Verse = ({
     })();
 
     return () => controller.abort();
-  }, [currVersionId, chapterId]);
+  }, [currVersionId, chapterId, setIsNotesOpen]);
 
-  // Keyboard navigation for chapters (only when a chapter is active)
+  // Available verse numbers for range picker
+  const verseNumbers = useMemo(() => {
+    const nums = verses.map((v) => Number(v.number)).filter((n) => !Number.isNaN(n));
+    nums.sort((a, b) => a - b);
+    return nums;
+  }, [verses]);
+
+  const startOptions = useMemo(() => {
+    if (!verseNumbers.length) return [];
+    if (rangeAnchor == null) return verseNumbers;
+    const idx = verseNumbers.findIndex((n) => n === rangeAnchor);
+    return idx >= 0 ? verseNumbers.slice(idx) : verseNumbers;
+  }, [verseNumbers, rangeAnchor]);
+
+  const endOptions = useMemo(() => {
+    if (!verseNumbers.length) return [];
+    const start = rangeStart ?? rangeAnchor;
+    if (start == null) return verseNumbers;
+    const idx = verseNumbers.findIndex((n) => n === start);
+    return idx >= 0 ? verseNumbers.slice(idx) : verseNumbers;
+  }, [verseNumbers, rangeStart, rangeAnchor]);
+
+  const minVerse = verseNumbers[0] ?? null;
+  const maxVerse = verseNumbers[verseNumbers.length - 1] ?? null;
+
+  // Display only selected range if activeRange is set
+  const visibleVerses = useMemo(() => {
+    if (!activeRange) return verses;
+    const { start, end } = activeRange;
+    return verses.filter((v) => v.number >= start && v.number <= end);
+  }, [verses, activeRange]);
+
+  // Pair verses visually: 2 verses per line
+  const pairedVerses = useMemo(() => {
+    const out = [];
+    for (let i = 0; i < visibleVerses.length; i += 2) {
+      out.push([visibleVerses[i], visibleVerses[i + 1]]);
+    }
+    return out;
+  }, [visibleVerses]);
+
+  const showArrows = hasChapter && (canPrev || canNext);
+
+  // ---------- Notes syncing (same editor, now range-aware title fallback) ----------
+  useEffect(() => {
+    if (!hasChapter) {
+      setIsNotesOpen?.(false);
+      setNoteDraft("");
+      setNoteTitleDraft("");
+      return;
+    }
+
+    if (isNotesOpen) {
+      const existing = getChapterNote?.(chapterId);
+      const rangeLabel =
+        activeRange ? ` (v${activeRange.start}–${activeRange.end})` : "";
+
+      const fallbackTitle = `Notes — ${book?.name || ""} ${chapterNumber}${rangeLabel}`.trim();
+
+      // if you already switched to {title,text} object, support both shapes safely:
+      const existingTitle =
+        typeof existing === "string" ? "" : (existing?.title || "");
+      const existingText =
+        typeof existing === "string" ? existing : (existing?.text || "");
+
+      setNoteTitleDraft(existingTitle || fallbackTitle);
+      setNoteDraft(existingText || "");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isNotesOpen, chapterId, hasChapter, activeRange]);
+
+  // Keyboard navigation (disable while notes or range modal open)
   useEffect(() => {
     if (!hasChapter) return;
 
@@ -156,6 +233,22 @@ const Verse = ({
           el.tagName === "TEXTAREA" ||
           el.isContentEditable);
       if (typing) return;
+
+      if (rangeModalOpen) {
+        if (e.key === "Escape") {
+          e.preventDefault();
+          setRangeModalOpen(false);
+        }
+        return;
+      }
+
+      if (isNotesOpen) {
+        if (e.key === "Escape") {
+          e.preventDefault();
+          setIsNotesOpen?.(false);
+        }
+        return;
+      }
 
       if (e.key === "ArrowLeft" && canPrev) {
         e.preventDefault();
@@ -169,64 +262,295 @@ const Verse = ({
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [hasChapter, canPrev, canNext, onPrev, onNext]);
+  }, [hasChapter, canPrev, canNext, onPrev, onNext, isNotesOpen, setIsNotesOpen, rangeModalOpen]);
 
-  const chapterNumber = hasChapter ? (chapterId.split(".")[1] || "") : "";
+  // -------- NEW: clicking a verse opens range picker modal --------
+  const openRangeModalFromVerse = (verseNumber) => {
+    if (!hasChapter) return;
 
-  // Pair verses visually: 2 verses per line
-  const pairedVerses = [];
-  for (let i = 0; i < verses.length; i += 2) {
-    pairedVerses.push([verses[i], verses[i + 1]]);
-  }
+    // ensure at least one verse: start=end=clicked
+    const n = Number(verseNumber);
+    if (Number.isNaN(n)) return;
 
-  const showArrows = hasChapter && (canPrev || canNext);
+    // if notes are open, close them first (optional but cleaner)
+    setIsNotesOpen?.(false);
+
+    setRangeAnchor(n);
+    setRangeStart(n);
+    setRangeEnd(n);
+    setRangeModalOpen(true);
+  };
+
+  const applyRange = () => {
+    if (rangeStart == null || rangeEnd == null) return;
+
+    const s = Number(rangeStart);
+    const e = Number(rangeEnd);
+    if (Number.isNaN(s) || Number.isNaN(e)) return;
+
+    const start = Math.min(s, e);
+    const end = Math.max(s, e);
+
+    const boundedStart = minVerse != null ? Math.max(start, minVerse) : start;
+    const boundedEnd = maxVerse != null ? Math.min(end, maxVerse) : end;
+
+    setActiveRange({ start: boundedStart, end: boundedEnd });
+
+    setRangeModalOpen(false);
+    if (user) setIsNotesOpen?.(true);
+  };
+
+
+  const clearRange = () => {
+    setActiveRange(null);
+  };
+
+  const toggleNotes = () => {
+    if (!hasChapter) return;
+    setIsNotesOpen?.((v) => !v);
+  };
+
+  const closeNotes = () => setIsNotesOpen?.(false);
+
+  const submitNotes = () => {
+    if (!hasChapter) return;
+    if (!user) return;
+
+    // support both your old "string note" and new "{title,text}" shapes
+    saveChapterNote?.(chapterId, {
+      title: noteTitleDraft,
+      text: noteDraft,
+    });
+
+    closeNotes();
+  };
 
   return (
-    <section className="DisplaySection">
+    <section className={`DisplaySection ${isNotesOpen ? "notesOpen" : ""}`}>
       <h2 className="bookChapterHeader">
         {hasChapter ? (
-          <span className="chapterTitle">
-            {book?.name || ""} {chapterNumber}
-          </span>
+          <div className="chapterHeaderStack">
+            <button
+              type="button"
+              className={`chapterTitle chapterTitleButton ${isNotesOpen ? "active" : ""}`}
+              onClick={toggleNotes}
+              aria-expanded={isNotesOpen ? "true" : "false"}
+              title="Click to add/view notes"
+            >
+              {book?.name || ""} {chapterNumber}
+              {activeRange ? ` (v${activeRange.start}–v${activeRange.end})` : ""}
+            </button>
+
+            {activeRange && (
+              <div className="clearRangeRow">
+                <button
+                  type="button"
+                  className="clearRangeBtn"
+                  onClick={clearRange}
+                  title="Show full chapter"
+                >
+                  Clear range
+                </button>
+              </div>
+            )}
+          </div>
+
         ) : (
-          <span className="chapterTitle placeholder">
-            Select a book and chapter to begin.
-          </span>
+          <span className="chapterTitle placeholder">Select a book and chapter to begin.</span>
         )}
       </h2>
 
-      <div className="displayArea">
-        {/* Content state */}
-        {error && hasChapter && (
-          <div role="alert">Error: {error}</div>
-        )}
+      {/* -------- Range Picker Modal -------- */}
+      {rangeModalOpen && (
+        <div
+          className="rangeModalOverlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Select verse range"
+          onMouseDown={() => setRangeModalOpen(false)}
+        >
+          <div className="rangeModalCard" onMouseDown={(e) => e.stopPropagation()}>
+            <div className="rangeModalHeader">
+              <div className="rangeModalTitle">
+                Select range (starting from v{rangeAnchor})
+              </div>
+              <button
+                type="button"
+                className="rangeModalClose"
+                onClick={() => setRangeModalOpen(false)}
+                aria-label="Close range selector"
+              >
+                ✕
+              </button>
+            </div>
 
-        {loading && hasChapter && !verses.length && (
-          <div>Loading verses…</div>
-        )}
+            <div className="rangeModalBody">
+              <div className="rangeRow">
+                <label className="rangeLabel">Start</label>
+                <select
+                  className="rangeSelect"
+                  value={rangeStart ?? ""}
+                  onChange={(e) => {
+                    const nextStart = Number(e.target.value);
+                    setRangeStart(nextStart);
+
+                    // keep end >= start
+                    if (rangeEnd == null || Number(rangeEnd) < nextStart) {
+                      setRangeEnd(nextStart);
+                    }
+                  }}
+                >
+                  {startOptions.map((n) => (
+                    <option key={`s-${n}`} value={n}>
+                      v{n}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="rangeRow">
+                <label className="rangeLabel">End</label>
+                <select
+                  className="rangeSelect"
+                  value={rangeEnd ?? ""}
+                  onChange={(e) => setRangeEnd(Number(e.target.value))}
+                >
+                  {endOptions.map((n) => (
+                    <option key={`e-${n}`} value={n}>
+                      v{n}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="rangeHint">
+                Must include at least one verse (defaults to the clicked verse).
+              </div>
+            </div>
+
+
+            <div className="rangeModalFooter">
+              <button
+                type="button"
+                className="rangeBtn rangeBtnGhost"
+                onClick={() => {
+                  // quick reset to just the clicked verse
+                  setRangeStart(rangeAnchor);
+                  setRangeEnd(rangeAnchor);
+                }}
+              >
+                Just v{rangeAnchor}
+              </button>
+
+              <button type="button" className="rangeBtn rangeBtnPrimary" onClick={applyRange}>
+                Apply range
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* -------- Notes editor (fixed bottom sheet) -------- */}
+      {hasChapter && isNotesOpen && (
+        <section className="chapterNotesShell" aria-label="Chapter notes editor">
+          <div className="chapterNotesInner">
+            <div className="chapterNotesHeader">
+              <input
+                className="chapterNotesTitleInput"
+                value={noteTitleDraft}
+                onChange={(e) => setNoteTitleDraft(e.target.value)}
+                placeholder={`Notes — ${book?.name || ""} ${chapterNumber}`}
+                disabled={!user || initializing}
+              />
+
+              <div className="chapterNotesActions">
+                <button type="button" className="notesBtn notesBtnGhost" onClick={closeNotes}>
+                  Exit
+                </button>
+                <button
+                  type="button"
+                  className="notesBtn notesBtnPrimary"
+                  onClick={submitNotes}
+                  disabled={!user || initializing}
+                  title={!user ? "Log in to save notes" : undefined}
+                >
+                  Submit
+                </button>
+              </div>
+            </div>
+
+            {!initializing && !user && (
+              <div className="notesLoginPrompt" role="status">
+                You must be logged in to write and save notes.
+              </div>
+            )}
+
+            <textarea
+              className="chapterNotesTextarea"
+              value={noteDraft}
+              onChange={(e) => setNoteDraft(e.target.value)}
+              placeholder={user ? "Write your notes here…" : "Log in to write notes…"}
+              disabled={!user || initializing}
+            />
+          </div>
+        </section>
+      )}
+
+      <div className="displayArea">
+        {error && hasChapter && <div role="alert">Error: {error}</div>}
+
+        {loading && hasChapter && !verses.length && <div>Loading verses…</div>}
 
         {hasChapter && !loading && !error && (
           <ol className="versesList">
             {pairedVerses.map(([v1, v2], idx) => (
               <li key={v1?.id || idx} className="verseRowPair">
                 {v1 && (
-                  <span className="verseChunk">
+                  <span
+                    role="button"
+                    tabIndex={0}
+                    className="verseInlineBtn"
+                    onClick={() => openRangeModalFromVerse(v1.number)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        openRangeModalFromVerse(v1.number);
+                      }
+                    }}
+                    title="Click to select verse range"
+                  >
                     <sup className="verseNum">{v1.number}</sup>
-                    {verseTexts[v1.id] ?? ""}
+                    <span className="verseText">{(verseTexts[v1.id] ?? "").replace(/\s+/g, " ").trim()}</span>
                   </span>
+
                 )}
+
                 {v2 && (
-                  <span className="verseChunk">
+                  <span
+                    role="button"
+                    tabIndex={0}
+                    className="verseInlineBtn"
+                    onClick={() => openRangeModalFromVerse(v1.number)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        openRangeModalFromVerse(v2.number);
+                      }
+                    }}
+                    title="Click to select verse range"
+                  >
                     <sup className="verseNum">{v2.number}</sup>
-                    {verseTexts[v2.id] ?? ""}
+                    <span className="verseText">{(verseTexts[v2.id] ?? "").replace(/\s+/g, " ").trim()}</span>
                   </span>
+
                 )}
               </li>
+
+
             ))}
           </ol>
         )}
 
-        {/* Arrows: only when a chapter exists & nav is possible */}
         {showArrows && (
           <section className="chapterNav">
             {canPrev && (
@@ -234,6 +558,7 @@ const Verse = ({
                 className="navArrow navArrowLeft"
                 onClick={onPrev}
                 aria-label="Previous chapter"
+                disabled={isNotesOpen || rangeModalOpen}
               >
                 ←
               </button>
@@ -243,6 +568,7 @@ const Verse = ({
                 className="navArrow navArrowRight"
                 onClick={onNext}
                 aria-label="Next chapter"
+                disabled={isNotesOpen || rangeModalOpen}
               >
                 →
               </button>


### PR DESCRIPTION
PR Title
Add verse-range notes flow with inline verse pairing

PR Description
This PR enhances the Bible reading experience by introducing verse-range–aware notes and improving verse layout consistency.

What’s included

Clicking a verse opens a range selector modal (minimum 1 verse enforced)

Range dropdowns now start from the clicked verse

After applying a verse range, the notes modal opens automatically

Notes context updates to reflect selected verse range

Verses remain paired in-line (e.g. v1 text, v2 text) instead of stacked

Chapter title remains centered with range controls positioned cleanly below

Notes editor remains fixed at the bottom for uninterrupted reading

Notes

No backend changes required

Fully compatible with existing auth logic (login required to save notes)