### PR TITLE
feat(notes): add scope and sort controls to notes drawer

### DIFF
--- a/src/pages/Study/Notes/NotesListDrawer.css
+++ b/src/pages/Study/Notes/NotesListDrawer.css
@@ -9,16 +9,16 @@
 
 .NotesListCard {
   width: min(520px, 92vw);
-  height: 100%;
   background: #fff;
+  height: 100vh;
+  margin: 0;
   box-shadow: -16px 0 40px rgba(0, 0, 0, 0.18);
   padding: 16px 16px 20px;
   overflow: hidden;
 
-  display: grid;
-  grid-template-rows: auto auto auto 1fr auto; 
+  display: flex;
+  flex-direction: column;
   gap: 10px;
-  min-height: 0;
 }
 
 .NotesListHeader {
@@ -62,22 +62,22 @@
   opacity: 0.75;
 }
 
-.NotesListCard .NotesList {
+.NotesList {
   list-style: none;
   padding: 0;
   margin: 0;
 
-  display: block !important;  
-  columns: 1 !important;      
-  column-count: 1 !important;
-  column-gap: 0 !important;
+  display: flex !important;
+  flex-direction: column;
+  gap: 10px;
 
   overflow-y: auto;
   min-height: 0;
-}
+  flex: 1;
 
-.NotesListCard .NotesListItem + .NotesListItem {
-  margin-top: 10px;
+  columns: 1 !important;
+  column-count: 1 !important;
+  column-gap: 0 !important;
 }
 
 .NotesListItemBtn {
@@ -123,9 +123,11 @@
 }
 
 .NotesListPager {
+  margin-top: auto;
   display: flex;
   align-items: center;
   gap: 10px;
+  padding: 20px 10px;
 }
 
 .NotesListPagerBtn {
@@ -144,4 +146,31 @@
 .NotesListPagerText {
   font-size: 13px;
   opacity: 0.8;
+}
+
+.NotesListControls {
+  display: flex;
+  gap: 12px;
+  padding: 10px 14px 6px 14px;
+  align-items: flex-end;
+}
+
+.NotesListControl {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 160px;
+}
+
+.NotesListControlLabel {
+  font-size: 12px;
+  opacity: 0.75;
+}
+
+.NotesListSelect {
+  height: 34px;
+  border-radius: 10px;
+  border: 1px solid rgba(0,0,0,0.18);
+  padding: 0 10px;
+  background: white;
 }

--- a/src/pages/Study/Notes/NotesListDrawer.js
+++ b/src/pages/Study/Notes/NotesListDrawer.js
@@ -1,9 +1,9 @@
 import "./NotesListDrawer.css";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState, useLayoutEffect } from "react";
 import { useNotesApi } from "./useNotesApi";
 import NoteDetailModal from "./NoteDetailModal";
 
-const PAGE_SIZE = 10;
+const ITEM_GAP_PX = 10;
 
 const shortPreview = (s, n = 140) => {
   const t = (s || "").toString().replace(/\s+/g, " ").trim();
@@ -34,22 +34,33 @@ const NotesListDrawer = ({
   const [err, setErr] = useState("");
   const [activeId, setActiveId] = useState(null);
 
-  // paging
   const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
 
-  const bookId = useMemo(() => {
-    if (!chapterId) return "";
-    return String(chapterId).split(".")[0] || "";
-  }, [chapterId]);
+  // NEW: scope + sort
+  const canUseChapterScope = !!chapterId;
+  const [scope, setScope] = useState("chapter"); // "chapter" | "all"
+  const [sortMode, setSortMode] = useState("recent"); // "recent" | "oldest" | "chapter"
+
+  const listRef = useRef(null);
+
+  // If drawer opens on a screen without chapterId, force "all"
+  useEffect(() => {
+    if (!open) return;
+    if (!canUseChapterScope) setScope("all");
+    else setScope((s) => (s === "all" ? "all" : "chapter"));
+  }, [open, canUseChapterScope]);
+
+  const sortParam = useMemo(() => {
+    if (sortMode === "oldest") return "createdAt:asc";
+    if (sortMode === "chapter") return "chapterId:asc";
+    return "updatedAt:desc"; // most recent
+  }, [sortMode]);
 
   const filterLabel = useMemo(() => {
-    if (!chapterId) return "All notes";
-    return `This chapter (${formatRef({
-      chapterId,
-      rangeStart: null,
-      rangeEnd: null,
-    })})`;
-  }, [chapterId]);
+    if (scope === "all" || !chapterId) return "All notes";
+    return `This chapter (${formatRef({ chapterId, rangeStart: null, rangeEnd: null })})`;
+  }, [scope, chapterId]);
 
   useEffect(() => {
     let alive = true;
@@ -64,19 +75,17 @@ const NotesListDrawer = ({
         const res = await listNotes({
           q: "",
           bibleId: bibleId || "",
-          bookId: bookId || "",
-          sort: "updatedAt:desc",
+          chapterId: scope === "chapter" ? chapterId : "",
+          sort: sortParam,
           limit: 200,
           offset: 0,
         });
 
         if (!alive) return;
 
-        let arr = Array.isArray(res.notes) ? res.notes : [];
-        if (chapterId) arr = arr.filter((n) => n.chapterId === chapterId);
-
+        const arr = Array.isArray(res.notes) ? res.notes : [];
         setNotes(arr);
-        setPage(1); // reset paging when drawer opens / filter changes
+        setPage(1);
       } catch (e) {
         if (!alive) return;
         setErr(
@@ -92,7 +101,7 @@ const NotesListDrawer = ({
     return () => {
       alive = false;
     };
-  }, [open, bibleId, bookId, chapterId, listNotes]);
+  }, [open, bibleId, chapterId, scope, sortParam, listNotes]);
 
   useEffect(() => {
     if (!open) return;
@@ -105,22 +114,55 @@ const NotesListDrawer = ({
     return () => window.removeEventListener("keydown", onKey);
   }, [open, onClose]);
 
+  useLayoutEffect(() => {
+    if (!open) return;
+    const el = listRef.current;
+    if (!el) return;
+
+    const compute = () => {
+      const containerH = el.clientHeight || 0;
+      if (!containerH) return;
+
+      const firstBtn = el.querySelector(".NotesListItemBtn");
+      if (!firstBtn) return;
+
+      const itemH = firstBtn.getBoundingClientRect().height || 0;
+      if (!itemH) return;
+
+      const fit = Math.max(
+        1,
+        Math.floor((containerH + ITEM_GAP_PX) / (itemH + ITEM_GAP_PX))
+      );
+
+      setPageSize((prev) => (prev === fit ? prev : fit));
+    };
+
+    compute();
+
+    const ro = new ResizeObserver(() => compute());
+    ro.observe(el);
+    window.addEventListener("resize", compute);
+
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("resize", compute);
+    };
+  }, [open, notes.length]);
+
   const totalNotes = notes.length;
-  const totalPages = Math.max(1, Math.ceil(totalNotes / PAGE_SIZE));
+  const totalPages = Math.max(1, Math.ceil(totalNotes / pageSize));
   const safePage = Math.min(Math.max(page, 1), totalPages);
 
-  const pageNotes = useMemo(() => {
-    const start = (safePage - 1) * PAGE_SIZE;
-    const end = start + PAGE_SIZE;
-    return notes.slice(start, end);
-  }, [notes, safePage]);
-
   useEffect(() => {
-    // keep page in range if notes change
     if (!open) return;
     if (page !== safePage) setPage(safePage);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [safePage, open, totalNotes]);
+  }, [open, page, safePage]);
+
+  const pageNotes = useMemo(() => {
+    const start = (safePage - 1) * pageSize;
+    const end = start + pageSize;
+    return notes.slice(start, end);
+  }, [notes, safePage, pageSize]);
 
   const canPrevPage = safePage > 1;
   const canNextPage = safePage < totalPages;
@@ -131,18 +173,43 @@ const NotesListDrawer = ({
   if (!open) return null;
 
   return (
-    <div
-      className="NotesListOverlay"
-      role="dialog"
-      aria-modal="true"
-      onMouseDown={onClose}
-    >
+    <div className="NotesListOverlay" role="dialog" aria-modal="true" onMouseDown={onClose}>
       <div className="NotesListCard" onMouseDown={(e) => e.stopPropagation()}>
         <div className="NotesListHeader">
           <div className="NotesListTitle">{title}</div>
           <button type="button" className="NotesListClose" onClick={onClose}>
             ✕
           </button>
+        </div>
+
+        {/* NEW controls row */}
+        <div className="NotesListControls">
+          <div className="NotesListControl">
+            <label className="NotesListControlLabel">Scope</label>
+            <select
+              className="NotesListSelect"
+              value={scope}
+              onChange={(e) => setScope(e.target.value)}
+              disabled={!canUseChapterScope}
+              title={!canUseChapterScope ? "Open from a chapter to enable this" : ""}
+            >
+              <option value="chapter">This chapter</option>
+              <option value="all">All notes</option>
+            </select>
+          </div>
+
+          <div className="NotesListControl">
+            <label className="NotesListControlLabel">Sort</label>
+            <select
+              className="NotesListSelect"
+              value={sortMode}
+              onChange={(e) => setSortMode(e.target.value)}
+            >
+              <option value="recent">Most recent</option>
+              <option value="oldest">Oldest</option>
+              <option value="chapter">By chapter</option>
+            </select>
+          </div>
         </div>
 
         <div className="NotesListSub">
@@ -163,63 +230,57 @@ const NotesListDrawer = ({
         )}
 
         {!loading && !err && totalNotes > 0 && (
-          <>
-            <ul className="NotesList">
-              {pageNotes.map((n) => (
-                <li key={n._id} className="NotesListItem">
-                  <button
-                    type="button"
-                    className="NotesListItemBtn"
-                    onClick={() => setActiveId(n._id)}
-                  >
-                    <div className="NotesListItemTop">
-                      <div className="NotesListItemTitle">{n.title || "Untitled"}</div>
-                      <div className="NotesListItemRef">{formatRef(n)}</div>
-                    </div>
-                    <div className="NotesListItemPreview">
-                      {shortPreview(n.preview ?? n.text)}
-                    </div>
-                    <div className="NotesListItemMeta">
-                      {n.updatedAt ? new Date(n.updatedAt).toLocaleString() : "—"}
-                    </div>
-                  </button>
-                </li>
-              ))}
-            </ul>
-
-            {totalPages > 1 && (
-              <div className="NotesListPager">
+          <ul className="NotesList" ref={listRef}>
+            {pageNotes.map((n) => (
+              <li key={n._id} className="NotesListItem">
                 <button
                   type="button"
-                  className="NotesListPagerBtn"
-                  onClick={goPrev}
-                  disabled={!canPrevPage}
-                  aria-label="Previous page"
+                  className="NotesListItemBtn"
+                  onClick={() => setActiveId(n._id)}
                 >
-                  ←
+                  <div className="NotesListItemTop">
+                    <div className="NotesListItemTitle">{n.title || "Untitled"}</div>
+                    <div className="NotesListItemRef">{formatRef(n)}</div>
+                  </div>
+                  <div className="NotesListItemPreview">{shortPreview(n.preview ?? n.text)}</div>
+                  <div className="NotesListItemMeta">
+                    {n.updatedAt ? new Date(n.updatedAt).toLocaleString() : "—"}
+                  </div>
                 </button>
-
-                <div className="NotesListPagerText">
-                  Page {safePage} / {totalPages}
-                </div>
-
-                <button
-                  type="button"
-                  className="NotesListPagerBtn"
-                  onClick={goNext}
-                  disabled={!canNextPage}
-                  aria-label="Next page"
-                >
-                  →
-                </button>
-              </div>
-            )}
-          </>
+              </li>
+            ))}
+          </ul>
         )}
 
-        {activeId && (
-          <NoteDetailModal noteId={activeId} onClose={() => setActiveId(null)} />
+        {totalPages > 1 && (
+          <div className="NotesListPager">
+            <button
+              type="button"
+              className="NotesListPagerBtn"
+              onClick={goPrev}
+              disabled={!canPrevPage}
+              aria-label="Previous page"
+            >
+              ←
+            </button>
+
+            <div className="NotesListPagerText">
+              Page {safePage} / {totalPages}
+            </div>
+
+            <button
+              type="button"
+              className="NotesListPagerBtn"
+              onClick={goNext}
+              disabled={!canNextPage}
+              aria-label="Next page"
+            >
+              →
+            </button>
+          </div>
         )}
+
+        {activeId && <NoteDetailModal noteId={activeId} onClose={() => setActiveId(null)} />}
       </div>
     </div>
   );


### PR DESCRIPTION
- Added scope toggle to notes drawer to switch between current chapter and all notes
- Added sort options: most recent, oldest, and by chapter
- Extended /notes/list API to support chapterId filtering and stable multi-key sorting
- Moved chapter filtering to the server to avoid client-side re-filtering
- Ensured pagination resets when scope or sort changes
- Disabled chapter scope when no chapter context is available
- Added drawer UI controls and minimal styling for scope and sort selectors
