### PR TITLE
feat(notes): allow inline deletion from notes drawer

### DIFF
--- a/src/pages/Study/Notes/NoteDetailModal.css
+++ b/src/pages/Study/Notes/NoteDetailModal.css
@@ -18,3 +18,31 @@
   background: rgba(20,20,20,0.98);
   padding: 16px;
 }
+
+.NoteModalActions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.NoteModalDeleteBtn {
+  border: 1px solid rgba(0,0,0,0.25);
+  border-radius: 10px;
+  padding: 8px 12px;
+  background: white;
+  cursor: pointer;
+}
+
+.NoteModalDeleteBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.NoteModalError {
+  margin-right: auto;
+  font-size: 13px;
+  color: #b00020;
+}

--- a/src/pages/Study/Notes/NoteDetailModal.js
+++ b/src/pages/Study/Notes/NoteDetailModal.js
@@ -1,11 +1,67 @@
 import "./NoteDetailModal.css";
+import { useState, useCallback } from "react";
+import { useNotesApi } from "./useNotesApi";
 import NoteDetail from "./NoteDetails";
 
-const NoteDetailModal = ({ noteId, onClose, onOpenPassage }) => {
+const NoteDetailModal = ({ noteId, onClose, onOpenPassage, onDeleted }) => {
+  const { deleteNote } = useNotesApi();
+
+  const [deleting, setDeleting] = useState(false);
+  const [deleteErr, setDeleteErr] = useState("");
+
+  const onDelete = useCallback(async () => {
+    if (!noteId || deleting) return;
+
+    const ok = window.confirm("Delete this note? This cannot be undone.");
+    if (!ok) return;
+
+    try {
+      setDeleteErr("");
+      setDeleting(true);
+
+      await deleteNote(noteId);
+
+      // Tell parent (drawer) so it can remove it from the list immediately
+      onDeleted?.(noteId);
+
+      // Close modal
+      onClose?.();
+    } catch (e) {
+      setDeleteErr(e.message || "Failed to delete note");
+    } finally {
+      setDeleting(false);
+    }
+  }, [noteId, deleting, deleteNote, onDeleted, onClose]);
+
+  if (!noteId) return null;
+
   return (
     <div className="NoteModalOverlay" role="dialog" aria-modal="true" onMouseDown={onClose}>
       <div className="NoteModalCard" onMouseDown={(e) => e.stopPropagation()}>
-        <NoteDetail noteId={noteId} onClose={onClose} onOpenPassage={onOpenPassage} />
+        {/* action row */}
+        <div className="NoteModalActions">
+          {deleteErr && (
+            <div className="NoteModalError" role="alert">
+              {deleteErr}
+            </div>
+          )}
+
+          <button
+            type="button"
+            className="NoteModalDeleteBtn"
+            onClick={onDelete}
+            disabled={deleting}
+            aria-label="Delete note"
+          >
+            {deleting ? "Deleting…" : "Delete"}
+          </button>
+        </div>
+
+        <NoteDetail
+          noteId={noteId}
+          onClose={onClose}
+          onOpenPassage={onOpenPassage}
+        />
       </div>
     </div>
   );

--- a/src/pages/Study/Notes/NotesListDrawer.css
+++ b/src/pages/Study/Notes/NotesListDrawer.css
@@ -151,7 +151,7 @@
 .NotesListControls {
   display: flex;
   gap: 12px;
-  padding: 10px 14px 6px 14px;
+  padding: 10px 0;
   align-items: flex-end;
 }
 
@@ -170,7 +170,51 @@
 .NotesListSelect {
   height: 34px;
   border-radius: 10px;
-  border: 1px solid rgba(0,0,0,0.18);
+  border: 1px solid rgba(0, 0, 0, 0.18);
   padding: 0 10px;
   background: white;
+}
+
+.NotesListItemTopRight {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.NotesListTrashBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background: white;
+  cursor: pointer;
+  flex: 0 0 auto;
+
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease;
+}
+
+.NotesListTrashBtn:hover {
+  border-color: rgba(0, 0, 0, 0.25);
+}
+
+.NotesListTrashBtn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.NotesListItemBtn:hover .NotesListTrashBtn,
+.NotesListTrashBtn:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.NotesListItemFlex {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }


### PR DESCRIPTION
- Added trash icon action to each note item in the notes drawer
- Enabled deleting notes directly without opening the detail modal
- Prevented row click propagation when deleting a note
- Added optimistic UI updates to remove deleted notes immediately
- Ensured active modal closes if its note is deleted inline
- Added per-item delete loading state and confirmation prompt
- Preserved pagination and drawer stability after deletions
