### PR TITLE
Sync notes drawer with modal edits and stabilize initial load

### DIFF
--- a/src/pages/Study/Notes/NoteDetailModal.css
+++ b/src/pages/Study/Notes/NoteDetailModal.css
@@ -1,7 +1,7 @@
 .NoteModalOverlay {
   position: fixed;
   inset: 0;
-  background: rgba(0,0,0,0.55);
+  background: rgba(0, 0, 0, 0.65);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -14,9 +14,27 @@
   max-height: 90vh;
   overflow: auto;
   border-radius: 18px;
-  border: 1px solid rgba(255,255,255,0.14);
-  background: rgba(20,20,20,0.98);
-  padding: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(18, 18, 18, 0.98);
+  color: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 16px 50px rgba(0, 0, 0, 0.55);
+}
+
+.NoteModalHeader {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: rgba(18, 18, 18, 0.98);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 14px 16px;
+}
+
+.NoteModalTitle {
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0.2px;
+  margin-bottom: 10px;
+  color: rgba(255, 255, 255, 0.95);
 }
 
 .NoteModalActions {
@@ -24,25 +42,45 @@
   align-items: center;
   justify-content: flex-end;
   gap: 10px;
-  padding: 10px 12px;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
 }
 
-.NoteModalDeleteBtn {
-  border: 1px solid rgba(0,0,0,0.25);
+.NoteModalBody {
+  padding: 16px;
+}
+
+.NoteModalBtn {
+  border: 1px solid rgba(255, 255, 255, 0.18);
   border-radius: 10px;
   padding: 8px 12px;
-  background: white;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.92);
   cursor: pointer;
 }
 
-.NoteModalDeleteBtn:disabled {
-  opacity: 0.6;
+.NoteModalBtn:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.NoteModalBtn:disabled {
+  opacity: 0.55;
   cursor: not-allowed;
+}
+
+.NoteModalDeleteBtn {
+  border-color: rgba(255, 80, 80, 0.35);
+  background: rgba(255, 80, 80, 0.14);
+}
+
+.NoteModalDeleteBtn:hover {
+  background: rgba(255, 80, 80, 0.2);
 }
 
 .NoteModalError {
   margin-right: auto;
   font-size: 13px;
-  color: #b00020;
+  color: rgba(255, 140, 140, 0.95);
+  background: rgba(255, 80, 80, 0.12);
+  border: 1px solid rgba(255, 80, 80, 0.25);
+  padding: 8px 10px;
+  border-radius: 10px;
 }

--- a/src/pages/Study/Notes/NoteDetailModal.js
+++ b/src/pages/Study/Notes/NoteDetailModal.js
@@ -3,7 +3,7 @@ import { useState, useCallback } from "react";
 import { useNotesApi } from "./useNotesApi";
 import NoteDetail from "./NoteDetails";
 
-const NoteDetailModal = ({ noteId, onClose, onOpenPassage, onDeleted }) => {
+const NoteDetailModal = ({ noteId, onClose, onOpenPassage, onDeleted, onUpdated }) => {
   const { deleteNote } = useNotesApi();
 
   const [deleting, setDeleting] = useState(false);
@@ -21,10 +21,7 @@ const NoteDetailModal = ({ noteId, onClose, onOpenPassage, onDeleted }) => {
 
       await deleteNote(noteId);
 
-      // Tell parent (drawer) so it can remove it from the list immediately
       onDeleted?.(noteId);
-
-      // Close modal
       onClose?.();
     } catch (e) {
       setDeleteErr(e.message || "Failed to delete note");
@@ -38,7 +35,6 @@ const NoteDetailModal = ({ noteId, onClose, onOpenPassage, onDeleted }) => {
   return (
     <div className="NoteModalOverlay" role="dialog" aria-modal="true" onMouseDown={onClose}>
       <div className="NoteModalCard" onMouseDown={(e) => e.stopPropagation()}>
-        {/* action row */}
         <div className="NoteModalActions">
           {deleteErr && (
             <div className="NoteModalError" role="alert">
@@ -46,13 +42,7 @@ const NoteDetailModal = ({ noteId, onClose, onOpenPassage, onDeleted }) => {
             </div>
           )}
 
-          <button
-            type="button"
-            className="NoteModalDeleteBtn"
-            onClick={onDelete}
-            disabled={deleting}
-            aria-label="Delete note"
-          >
+          <button type="button" className="NoteModalDeleteBtn" onClick={onDelete} disabled={deleting}>
             {deleting ? "Deleting…" : "Delete"}
           </button>
         </div>
@@ -61,6 +51,7 @@ const NoteDetailModal = ({ noteId, onClose, onOpenPassage, onDeleted }) => {
           noteId={noteId}
           onClose={onClose}
           onOpenPassage={onOpenPassage}
+          onUpdated={onUpdated} 
         />
       </div>
     </div>

--- a/src/pages/Study/Notes/NoteDetails.css
+++ b/src/pages/Study/Notes/NoteDetails.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
+  padding: 10px 20px;
 }
 
 .NoteDetailTop {
@@ -106,4 +107,10 @@
 
 .NoteBtnGhost {
   background: transparent;
+}
+
+.NoteModalDeleteBtn {
+  color: white;
+  padding: 3px 5px;
+  margin: 3px 15px;
 }

--- a/src/pages/Study/Notes/useNotesApi.js
+++ b/src/pages/Study/Notes/useNotesApi.js
@@ -2,12 +2,24 @@ import { useCallback } from "react";
 
 const API_BASE = process.env.REACT_APP_API_BASE_URL || "http://localhost:4000";
 
-const jsonFetch = async (path, opts = {}) => {
+const buildQS = (params) => {
+  const qs = new URLSearchParams();
+  Object.entries(params || {}).forEach(([k, v]) => {
+    if (v === undefined || v === null || v === "") return;
+    qs.set(k, String(v));
+  });
+  const s = qs.toString();
+  return s ? `?${s}` : "";
+};
+
+const request = async (path, opts = {}) => {
+  const hasBody = opts.body !== undefined && opts.body !== null;
+
   const res = await fetch(`${API_BASE}${path}`, {
     credentials: "include",
     ...opts,
     headers: {
-      "Content-Type": "application/json",
+      ...(hasBody ? { "Content-Type": "application/json" } : {}),
       ...(opts.headers || {}),
     },
   });
@@ -16,12 +28,22 @@ const jsonFetch = async (path, opts = {}) => {
   try {
     data = await res.json();
   } catch {
-    // ignore
+    // ignore (non-json response)
   }
 
+  // Handle HTTP errors
   if (!res.ok) {
     const err = new Error(data?.error || `HTTP ${res.status}`);
     err.status = res.status;
+    err.data = data;
+    throw err;
+  }
+
+  // Handle app-level errors: { ok:false, error:"..." }
+  if (data && typeof data === "object" && data.ok === false) {
+    const err = new Error(data?.error || "Request failed");
+    err.status = res.status;
+    err.data = data;
     throw err;
   }
 
@@ -29,46 +51,81 @@ const jsonFetch = async (path, opts = {}) => {
 };
 
 export const useNotesApi = () => {
+  /**
+   * GET /notes/list?q=&bibleId=&bookId=&chapterId=&sort=&limit=&offset=
+   * -> { ok:true, notes:[...], total:number }
+   */
   const listNotes = useCallback(async (params) => {
-    const qs = new URLSearchParams();
-    Object.entries(params || {}).forEach(([k, v]) => {
-      if (v === undefined || v === null || v === "") return;
-      qs.set(k, String(v));
-    });
-    return jsonFetch(`/notes/list?${qs.toString()}`);
+    return request(`/notes/list${buildQS(params)}`, { method: "GET" });
   }, []);
 
+  /**
+   * GET /notes/:id
+   * -> { ok:true, note:{...} }
+   */
   const getNote = useCallback(async (id) => {
-    return jsonFetch(`/notes/${encodeURIComponent(id)}`);
+    if (!id) throw new Error("Missing note id");
+    return request(`/notes/${encodeURIComponent(id)}`, { method: "GET" });
   }, []);
 
+  /**
+   * GET /notes?bibleId=&chapterId=&rangeStart=&rangeEnd=
+   * -> { ok:true, note:{...} | null }
+   */
   const getScopedNote = useCallback(async (params) => {
-    const qs = new URLSearchParams();
-    Object.entries(params || {}).forEach(([k, v]) => {
-      if (v === undefined || v === null || v === "") return;
-      qs.set(k, String(v));
-    });
-    return jsonFetch(`/notes?${qs.toString()}`);
+    return request(`/notes${buildQS(params)}`, { method: "GET" });
   }, []);
 
+  /**
+   * GET /notes/exists?bibleId=&chapterId=
+   * -> { ok:true, hasAnyNote:boolean }
+   */
+  const hasAnyNotes = useCallback(async (params) => {
+    return request(`/notes/exists${buildQS(params)}`, { method: "GET" });
+  }, []);
+
+  /**
+   * POST /notes
+   * body: { bibleId, chapterId, rangeStart, rangeEnd, title, text }
+   * -> { ok:true, note:{...} }
+   */
   const createNote = useCallback(async (payload) => {
-    return jsonFetch(`/notes`, {
+    return request(`/notes`, {
       method: "POST",
       body: JSON.stringify(payload || {}),
     });
   }, []);
 
-  // edit existing note by id
+  /**
+   * PUT /notes/:id
+   * body: { title, text }
+   * -> { ok:true, note:{...} }
+   */
   const updateNote = useCallback(async (id, payload) => {
-    return jsonFetch(`/notes/${encodeURIComponent(id)}`, {
+    if (!id) throw new Error("Missing note id");
+    return request(`/notes/${encodeURIComponent(id)}`, {
       method: "PUT",
       body: JSON.stringify(payload || {}),
     });
   }, []);
 
+  /**
+   * DELETE /notes/:id
+   * -> { ok:true }
+   */
   const deleteNote = useCallback(async (id) => {
-    return jsonFetch(`/notes/${encodeURIComponent(id)}`, { method: "DELETE" });
+    if (!id) throw new Error("Missing note id");
+    await request(`/notes/${encodeURIComponent(id)}`, { method: "DELETE" });
+    return true;
   }, []);
 
-  return { listNotes, getNote, getScopedNote, createNote, updateNote, deleteNote };
+  return {
+    listNotes,
+    getNote,
+    getScopedNote,
+    hasAnyNotes,
+    createNote,
+    updateNote,
+    deleteNote,
+  };
 };


### PR DESCRIPTION
- Wire note edit flow to immediately update drawer list without refetch
- Bubble updated note data from NoteDetails → modal → drawer
- Patch drawer state in-place on note save and delete
- Preserve existing drawer layout and styling with minimal CSS changes
- Stabilize drawer initial load by guarding pageSize recalculations
- Reduce redundant fetches caused by ResizeObserver and paging effects
