### PR TITLE
refactor(community): unify post type rendering + add inline edit head…

### DIFF
--- a/src/pages/Community/myCommunity/MyCommunity.css
+++ b/src/pages/Community/myCommunity/MyCommunity.css
@@ -6,7 +6,7 @@
   flex-direction: column;
 }
 
-.ForumContainer> :last-child {
+.ForumContainer > :last-child {
   margin-top: auto;
 }
 
@@ -36,15 +36,12 @@
 }
 
 .ForumHero {
-  /* background-image: url("../../../component/images/community/CommunityDefaultHero.png"); */
   background-color: #00000080;
   background-blend-mode: saturation;
-
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
   min-height: 400px;
-
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -52,7 +49,6 @@
   position: relative;
 }
 
-/* Container for the small "+" box */
 .HeroUploadControl {
   position: absolute;
   right: 18px;
@@ -60,10 +56,8 @@
   opacity: 0;
   transition: opacity 0.2s ease-in-out;
   pointer-events: none;
-  /* until hover */
 }
 
-/* Show it on hover over hero */
 .ForumHero:hover .HeroUploadControl {
   opacity: 1;
   pointer-events: auto;
@@ -93,7 +87,6 @@
   cursor: default;
 }
 
-/* hide actual input */
 .HeroUploadInput {
   display: none;
 }
@@ -179,154 +172,6 @@
   width: 80%;
   margin: 0 auto;
 }
-
-/* ===========================
-   New Post Modal
-   =========================== */
-
-.NewPostOverlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.45);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 4000;
-}
-
-.NewPostModal {
-  background: #f4eee6;
-  border-radius: 12px;
-  width: min(520px, 92vw);
-  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
-  padding: 20px 24px 24px;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.NewPostHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 4px;
-}
-
-.NewPostHeader h2 {
-  font-size: 20px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-}
-
-.NewPostCloseButton {
-  background: none;
-  border: none;
-  font-size: 24px;
-  line-height: 1;
-  cursor: pointer;
-  padding: 2px 4px;
-  color: #222;
-}
-
-.NewPostForm {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-.NewPostField {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.NewPostField label {
-  font-size: 13px;
-  font-weight: 500;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: #333;
-}
-
-.NewPostField input,
-.NewPostField select,
-.NewPostField textarea {
-  border-radius: 6px;
-  border: 1px solid #c7b9a4;
-  padding: 8px 10px;
-  font-size: 14px;
-  font-family: inherit;
-  background: #fffdf9;
-}
-
-.NewPostField input:focus,
-.NewPostField select:focus,
-.NewPostField textarea:focus {
-  outline: 2px solid #0f0f0f;
-  outline-offset: 1px;
-}
-
-.NewPostField textarea {
-  resize: vertical;
-  min-height: 120px;
-}
-
-/* Modal actions */
-.NewPostActions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 10px;
-  margin-top: 6px;
-}
-
-.NewPostPrimaryButton {
-  background: #000;
-  color: #fff;
-  font-size: 14px;
-  padding: 8px 18px;
-  border-radius: 6px;
-  border: none;
-  cursor: pointer;
-}
-
-.NewPostSecondaryButton {
-  background: transparent;
-  color: #333;
-  font-size: 14px;
-  padding: 8px 14px;
-  border-radius: 6px;
-  border: 1px solid #c7b9a4;
-  cursor: pointer;
-}
-
-.NewPostPrimaryButton:hover {
-  opacity: 0.9;
-}
-
-.NewPostSecondaryButton:hover {
-  background: #f0e4d4;
-}
-
-.Tag.general {
-  background: #c8d1b2;
-}
-
-.Tag.questions {
-  background: #8BBF7F;
-}
-
-.Tag.announcements {
-  background: #d3a78c;
-}
-
-.Tag.feedback {
-  background: #b9a5d6;
-}
-
-/* ===========================
-   New Post Modal – base styles
-   =========================== */
 
 .NewPostOverlay {
   position: fixed;
@@ -421,7 +266,6 @@
   min-height: 120px;
 }
 
-/* Validation styling */
 .NewPostField.has-error input,
 .NewPostField.has-error textarea {
   border-color: #c04747;
@@ -432,7 +276,6 @@
   color: #c04747;
 }
 
-/* Global submit error */
 .NewPostGlobalError {
   background: #fbe4e4;
   color: #6b2020;
@@ -442,7 +285,6 @@
   margin-bottom: 6px;
 }
 
-/* Modal actions */
 .NewPostActions {
   display: flex;
   justify-content: flex-end;
@@ -484,13 +326,26 @@
   cursor: default;
 }
 
-/* Tag color for Poll posts */
-.Tag.poll {
-  background: #b9a5d6;
-  /* similar vibe to feedback color */
+.Tag.general {
+  background: #c8d1b2;
 }
 
-/* Poll options list */
+.Tag.questions {
+  background: #8BBF7F;
+}
+
+.Tag.announcements {
+  background: #d3a78c;
+}
+
+.Tag.feedback {
+  background: #b9a5d6;
+}
+
+.Tag.poll {
+  background: #b9a5d6;
+}
+
 .PollOptionsList {
   display: flex;
   flex-direction: column;
@@ -535,7 +390,6 @@
   background: #f0e4d4;
 }
 
-/* Poll settings */
 .PollSettingsField label {
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -574,21 +428,16 @@
 .CommunityBackArrow {
   position: absolute;
   top: 84px;
-  /* tweak if PageHeader overlaps */
   left: 18px;
-
   width: 40px;
   height: 40px;
   border-radius: 999px;
-
   border: 1px solid rgba(245, 235, 222, 0.9);
   background: rgba(0, 0, 0, 0.55);
   color: #f5ebde;
-
   display: flex;
   align-items: center;
   justify-content: center;
-
   cursor: pointer;
   font-size: 18px;
   line-height: 1;
@@ -598,9 +447,8 @@
   background: rgba(0, 0, 0, 0.75);
 }
 
-
 .ForumActionsCol {
-  width: 120px;
+  width: 64px;
   text-align: right;
 }
 
@@ -609,40 +457,34 @@
   white-space: nowrap;
 }
 
-.PostActionButtons {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.PostIconButton {
+.PostDeleteIcon {
+  opacity: 0;
   border: none;
   background: transparent;
   cursor: pointer;
-  padding: 6px 8px;
-  border-radius: 10px;
-  font-size: 16px;
-  line-height: 1;
+  padding: 6px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.15s ease, background 0.15s ease, transform 0.15s ease;
 }
 
-.PostIconButton:hover {
-  background: rgba(0, 0, 0, 0.06);
+.ForumRow:hover .PostDeleteIcon {
+  opacity: 1;
+  transform: translateY(-1px);
 }
 
-.PostIconButton:disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
+.PostDeleteIcon:hover:not(:disabled) {
+  background: rgba(255, 0, 0, 0.08);
+  color: #b3261e;
 }
 
-.PostIconButton--danger:hover {
-  background: rgba(255, 0, 0, 0.10);
+.PostDeleteIcon:disabled {
+  opacity: 0.4;
+  cursor: default;
+  transform: none;
 }
-
-
-
-/* ===========================
-   Mobile tweaks
-   =========================== */
 
 @media (max-width: 600px) {
   .ForumBody {

--- a/src/pages/Community/myCommunity/MyCommunity.js
+++ b/src/pages/Community/myCommunity/MyCommunity.js
@@ -7,6 +7,8 @@ import Footer from "../../../component/Footer";
 import NewPostModal from "./NewPost";
 import Time from "../../../component/utils/Time";
 import { apiFetch } from "../../../component/utils/ApiFetch";
+import { FiTrash2 } from "react-icons/fi";
+
 import {
   COMMUNITY_ACTIVITY_EVENT,
   emitCommunityActivityUpdated,
@@ -370,33 +372,22 @@ const MyCommunity = () => {
                   <td>{post.replyCount}</td>
                   <td>{formatActivity(post)}</td>
                   {/* Forum delete / edit section */}
-                  <td className="ForumActionsCell" onClick={(e) => e.stopPropagation()}>
-                    {canEditOrDeletePost(post) ? (
-                      <div className="PostActionButtons">
-                        <button
-                          type="button"
-                          className="PostIconButton"
-                          aria-label="Edit post"
-                          title="Edit"
-                          onClick={() => navigate(`/community/${communityId}/posts/${post.id}/edit`)}
-                          disabled={deletingPostId === String(post.id)}
-                        >
-                          ✎
-                        </button>
-
-                        <button
-                          type="button"
-                          className="PostIconButton PostIconButton--danger"
-                          aria-label="Delete post"
-                          title="Delete"
-                          onClick={() => handleDeletePost(post.id)}
-                          disabled={deletingPostId === String(post.id)}
-                        >
-                          🗑
-                        </button>
-                      </div>
-                    ) : (
-                      <span className="PostActionPlaceholder">—</span>
+                  <td
+                    className={`ForumActionsCell ${canEditOrDeletePost(post) ? "can-delete" : ""
+                      }`}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    {canEditOrDeletePost(post) && (
+                      <button
+                        type="button"
+                        className="PostDeleteIcon"
+                        aria-label="Delete post"
+                        title="Delete"
+                        onClick={() => handleDeletePost(post.id)}
+                        disabled={deletingPostId === String(post.id)}
+                      >
+                        <FiTrash2 size={16} />
+                      </button>
                     )}
                   </td>
                 </tr>

--- a/src/pages/Community/myCommunity/postDetail/PostDetail.css
+++ b/src/pages/Community/myCommunity/postDetail/PostDetail.css
@@ -53,6 +53,145 @@
   color: #333;
 }
 
+.PostDetailEditableGroup {
+  position: relative;
+  border-radius: 10px;
+}
+
+.PostDetailEditableGroup.can-edit {
+  padding-top: 2px;
+}
+
+.PostDetailEditIcon {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  opacity: 0;
+  border: none;
+  background: rgba(255, 255, 255, 0.75);
+  backdrop-filter: blur(6px);
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.15s ease, transform 0.15s ease, background 0.15s ease;
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.PostDetailEditableGroup.can-edit:hover .PostDetailEditIcon {
+  opacity: 1;
+  transform: translateY(-1px);
+}
+
+.PostDetailEditIcon:hover {
+  background: rgba(255, 255, 255, 0.95);
+  color: rgba(0, 0, 0, 0.9);
+}
+
+.PostDetailEditPanel {
+  margin-top: 10px;
+  padding: 14px 14px 12px;
+  border-radius: 12px;
+  background: #fffdf9;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.PostDetailEditError {
+  background: #fbe4e4;
+  color: #6b2020;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 13px;
+  margin-bottom: 10px;
+}
+
+.PostDetailEditField {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.PostDetailEditField label {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #333;
+}
+
+.PostDetailEditField input,
+.PostDetailEditField textarea {
+  border-radius: 8px;
+  border: 1px solid #c7b9a4;
+  padding: 10px 10px;
+  font-size: 14px;
+  font-family: inherit;
+  background: #fffdf9;
+}
+
+.PostDetailEditField input:focus,
+.PostDetailEditField textarea:focus {
+  outline: 2px solid #0f0f0f;
+  outline-offset: 1px;
+}
+
+.PostDetailEditField textarea {
+  resize: vertical;
+  min-height: 140px;
+  white-space: pre-line;
+  line-height: 1.6;
+}
+
+.PostDetailEditActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.PostDetailEditPrimary {
+  background: #000;
+  color: #fff;
+  font-size: 14px;
+  padding: 8px 16px;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+}
+
+.PostDetailEditSecondary {
+  background: transparent;
+  color: #333;
+  font-size: 14px;
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid #c7b9a4;
+  cursor: pointer;
+}
+
+.PostDetailEditPrimary:disabled,
+.PostDetailEditSecondary:disabled {
+  opacity: 0.65;
+  cursor: default;
+}
+
+.PostDetailEditPrimary:hover:not(:disabled) {
+  opacity: 0.92;
+}
+
+.PostDetailEditSecondary:hover:not(:disabled) {
+  background: #f0e4d4;
+}
+
+.PostDetailEditHint {
+  margin-top: 8px;
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.55);
+}
+
 .PostDetailSubTitle {
   font-size: 18px;
   padding: 20px 0;

--- a/src/pages/Community/myCommunity/postDetail/PostDetail.js
+++ b/src/pages/Community/myCommunity/postDetail/PostDetail.js
@@ -1,3 +1,4 @@
+import { useCallback, useMemo } from "react";
 import PageHeader from "../../../../component/PageHeader";
 import Footer from "../../../../component/Footer";
 import "../MyCommunity.css";
@@ -13,6 +14,8 @@ import usePostDetailData from "./hooks/usePostDetailData";
 import usePostReplies from "./hooks/usePostReplies";
 import useReplyTree from "./hooks/useReplyTree";
 import useThreadExpansion from "./hooks/useThreadExpansion";
+
+import { apiFetch } from "../../../../component/utils/ApiFetch";
 
 const PostDetail = () => {
   const {
@@ -62,6 +65,52 @@ const PostDetail = () => {
   const replyTree = useReplyTree(replies);
   const { expanded, toggleExpanded, deepExpanded, toggleDeepExpanded } = useThreadExpansion();
 
+  const canEditPost = useMemo(() => {
+    if (!post) return false;
+
+    const currentId = String(myUserId || "");
+    if (!currentId) return false;
+
+    const authorId = String(post.authorId || "");
+    const isAuthor = authorId && authorId === currentId;
+
+    const isLeaderOrOwner =
+      Array.isArray(community?.members) &&
+      community.members.some(
+        (m) =>
+          (m.role === "Owner" || m.role === "Leader") &&
+          String(m.id || m._id || "") === currentId
+      );
+
+    return isAuthor || isLeaderOrOwner;
+  }, [post, myUserId, community]);
+
+  const handleSavePostHeader = useCallback(
+    async (payload) => {
+      try {
+        if (!communityId || !postId) return { ok: false, error: "Missing communityId/postId." };
+
+        const res = await apiFetch(`/community/${communityId}/posts/${postId}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+
+        const data = await res.json().catch(() => ({}));
+
+        if (!res.ok || !data.ok) {
+          return { ok: false, error: data.error || "Failed to save post." };
+        }
+
+        await refetchPost();
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e?.message || "Failed to save post." };
+      }
+    },
+    [communityId, postId, refetchPost]
+  );
+
   if (loading) {
     return (
       <PostDetailShell heroStyle={heroStyle} PageHeader={PageHeader} Footer={Footer}>
@@ -92,14 +141,11 @@ const PostDetail = () => {
     <section className="ForumContainer">
       <div className="ForumHero ForumHero--small" style={heroStyle}>
         <PageHeader />
-        <PostHeroHeader
-          communityHeader={community?.header || "Community"}
-          communityId={communityId}
-        />
+        <PostHeroHeader communityHeader={community?.header || "Community"} communityId={communityId} />
       </div>
 
       <section className="ForumBody PostDetailBody">
-        <PostHeader post={post} />
+        <PostHeader post={post} canEdit={canEditPost} onSave={handleSavePostHeader} />
 
         {post.type === "poll" && (
           <PollSection

--- a/src/pages/Community/myCommunity/postDetail/components/PostHeader.js
+++ b/src/pages/Community/myCommunity/postDetail/components/PostHeader.js
@@ -1,37 +1,181 @@
-import Time from "../../../../../component/utils/Time";
+import { useMemo, useState, useCallback, useEffect } from "react";
+import { FiEdit3 } from "react-icons/fi"; import Time from "../../../../../component/utils/Time";
+import { getTypeLabel, getTypeTagClass } from "../../../communityTypes";
 
-const PostHeader = ({ post }) => {
-  const { title, body, type, createdAt, updatedAt, author } = post || {};
+const PostHeader = ({ post, canEdit = false, onSave }) => {
+  const { id, title, body, type, createdAt, updatedAt, author } = post || {};
 
-  const typeLabel =
-    type === "questions"
-      ? "Questions"
-      : type === "announcements"
-      ? "Announcements"
-      : type === "poll"
-      ? "📊 Poll"
-      : "Bible Study";
+  const [isEditing, setIsEditing] = useState(false);
+  const [draftTitle, setDraftTitle] = useState(title || "");
+  const [draftBody, setDraftBody] = useState(body || "");
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState("");
+
+  useEffect(() => {
+    setDraftTitle(title || "");
+    setDraftBody(body || "");
+  }, [title, body]);
 
   const activityText = Time(updatedAt || createdAt);
 
+  const openEdit = useCallback(
+    (e) => {
+      e?.stopPropagation?.();
+      if (!canEdit) return;
+      setSaveError("");
+      setDraftTitle(title || "");
+      setDraftBody(body || "");
+      setIsEditing(true);
+    },
+    [canEdit, title, body]
+  );
+
+  const closeEdit = useCallback(() => {
+    if (saving) return;
+    setSaveError("");
+    setIsEditing(false);
+    setDraftTitle(title || "");
+    setDraftBody(body || "");
+  }, [saving, title, body]);
+
+  const canSubmit = useMemo(() => {
+    const t = String(draftTitle || "").trim();
+    if (!t) return false;
+
+    if (type !== "poll") {
+      const b = String(draftBody || "").trim();
+      if (!b) return false;
+    }
+    return true;
+  }, [draftTitle, draftBody, type]);
+
+  const handleSave = useCallback(async () => {
+    if (!canEdit || typeof onSave !== "function" || !id) return;
+    if (!canSubmit) return;
+
+    setSaving(true);
+    setSaveError("");
+
+    try {
+      const payload = {
+        title: String(draftTitle || "").trim(),
+        body: draftBody ?? "",
+        type: type || "general",
+      };
+
+      const res = await onSave(payload);
+
+      if (!res?.ok) {
+        throw new Error(res?.error || "Failed to save.");
+      }
+
+      setIsEditing(false);
+    } catch (e) {
+      setSaveError(e?.message || "Failed to save.");
+    } finally {
+      setSaving(false);
+    }
+  }, [canEdit, onSave, id, canSubmit, draftTitle, draftBody, type]);
+
+  const onKeyDown = (e) => {
+    if (!isEditing) return;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      closeEdit();
+    }
+    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "enter") {
+      e.preventDefault();
+      handleSave();
+    }
+  };
+
   return (
-    <header className="PostDetailHeader">
+    <header className="PostDetailHeader" onKeyDown={onKeyDown}>
       <div className="PostDetailMetaRow">
-        <span className={`Tag ${type || "general"}`}>
-          {type === "poll" ? "📊 Poll" : typeLabel}
+        <span className={`Tag ${getTypeTagClass(post)}`}>
+          {getTypeLabel(post)}
         </span>
         <span className="PostDetailMetaText">
           Posted by {author || "Unknown"} · {activityText}
         </span>
       </div>
 
-      <h1 className="PostDetailTitle">{title}</h1>
+      <div
+        className={[
+          "PostDetailEditableGroup",
+          canEdit ? "can-edit" : "",
+          isEditing ? "is-editing" : "",
+        ].join(" ")}
+      >
+        {!isEditing ? (
+          <>
+            <h1 className="PostDetailTitle">{title}</h1>
 
-      {body && (
-        <article className="PostDetailContent">
-          <p>{body}</p>
-        </article>
-      )}
+            {body && (
+              <article className="PostDetailContent">
+                <p>{body}</p>
+              </article>
+            )}
+
+            {canEdit && (
+              <button
+                type="button"
+                className="PostDetailEditIcon"
+                aria-label="Edit post"
+                title="Edit"
+                onClick={openEdit}
+              >
+                <FiEdit3 size={16} />
+              </button>
+            )}
+          </>
+        ) : (
+          <div className="PostDetailEditPanel" onClick={(e) => e.stopPropagation()}>
+            {saveError && <div className="PostDetailEditError">{saveError}</div>}
+
+            <div className="PostDetailEditField">
+              <label>Title</label>
+              <input
+                value={draftTitle}
+                onChange={(e) => setDraftTitle(e.target.value)}
+                disabled={saving}
+                placeholder="Post title"
+              />
+            </div>
+
+            <div className="PostDetailEditField">
+              <label>Body</label>
+              <textarea
+                value={draftBody}
+                onChange={(e) => setDraftBody(e.target.value)}
+                disabled={saving || type === "poll"}
+                placeholder={type === "poll" ? "Poll posts don’t require body." : "Write your post..."}
+              />
+            </div>
+
+            <div className="PostDetailEditActions">
+              <button
+                type="button"
+                className="PostDetailEditSecondary"
+                onClick={closeEdit}
+                disabled={saving}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="PostDetailEditPrimary"
+                onClick={handleSave}
+                disabled={saving || !canSubmit}
+              >
+                {saving ? "Saving…" : "Save"}
+              </button>
+            </div>
+
+            <div className="PostDetailEditHint">Press Esc to cancel · Ctrl/⌘ + Enter to save</div>
+          </div>
+        )}
+      </div>
     </header>
   );
 };


### PR DESCRIPTION
Centralized PostDetail type rendering to use getTypeLabel and getTypeTagClass from communityTypes

Removed duplicated type label logic from PostHeader

Ensured consistent category icons, labels, and tag classes between MyCommunity and PostDetail

Added hover-based header action UI with edit icon

Implemented inline edit panel for post title/body with keyboard shortcuts (Esc to cancel, Ctrl/⌘+Enter to save)

Improved edit state sync when post updates

Cleaned up styling for header action icons and edit panel

Improves consistency across community views and removes duplicated type logic while enhancing post editing UX.