### PR TITLE
Add community member management permissions + invite-by-username/email

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -30,6 +30,7 @@ import BibleWalkthrough from "./pages/Study/BibleWalkthrough";
 import NotesPage from "./pages/Study/Notes/NotesPage";
 import NotePage from "./pages/Study/Notes/NotePage";
 import CommunityOverview from "./pages/Community/myCommunity/CommunityOverview";
+import MemberManage from "./pages/Community/myCommunity/MemberManage";
 
 function App() {
   return (
@@ -65,6 +66,7 @@ function App() {
                   <Route path="/check-email" element={<CheckEmail />} />
                   <Route path="/verify-email" element={<VerifyEmail />} />
                   <Route path="/reset-password" element={<ResetPassword />} />
+                  <Route path="/community/:communityId/members/manage" element={<MemberManage />} />
                 </Routes>
               </ToastProvider>
             </NotificationProvider>

--- a/src/pages/Account/Account.css
+++ b/src/pages/Account/Account.css
@@ -62,11 +62,13 @@
 .account-input {
   width: 100%;
   padding: 0.7rem 0.9rem;
-  border: 1px solid #cfd4dc;
+  border: 1px solid rgba(255, 255, 255, 0.18);
   border-radius: 10px;
   font-size: 1rem;
   outline: none;
-  background: #fff;
+
+  background: rgba(255, 255, 255, 0.06);
+  color: #f5eaea;
 }
 
 .signup-name-flex {
@@ -577,6 +579,11 @@
   border-radius: 8px;
   margin-bottom: 0.75rem;
   font-size: 0.95rem;
+}
+
+.account-input[readonly] {
+  background: rgba(0, 0, 0, 0.03);
+  cursor: default;
 }
 
 @media (max-width: 480px) {

--- a/src/pages/Account/email/CheckEmail.js
+++ b/src/pages/Account/email/CheckEmail.js
@@ -10,7 +10,7 @@ export default function CheckEmail() {
   const emailFromState = location.state?.email || "";
   const sentFromState = location.state?.sent;
 
-  const [email, setEmail] = useState(emailFromState);
+  const email = emailFromState;
   const [status, setStatus] = useState(
     sentFromState === false ? "Email failed to send. Please resend." : ""
   );
@@ -72,7 +72,8 @@ export default function CheckEmail() {
           </div>
 
           <div className="account-info" role="note">
-            If you don’t see it, check spam/junk. Some providers delay new senders by a few minutes.
+            If you don’t see it, check spam/junk. <br/>
+            Some providers delay new senders by a few minutes.
           </div>
 
           {status && (
@@ -91,12 +92,10 @@ export default function CheckEmail() {
             <label className="account-label">
               Email
               <input
-                ref={inputRef}
                 type="email"
                 value={email}
-                onChange={(e) => setEmail(e.target.value)}
+                readOnly
                 className="account-input"
-                placeholder="Email Address"
                 maxLength={254}
               />
               <div className="account-help-small">Didn’t get it? Resend below.</div>

--- a/src/pages/Account/findUser/FindPw.js
+++ b/src/pages/Account/findUser/FindPw.js
@@ -49,7 +49,6 @@ export default function FindPw() {
         throw new Error(data?.error || "Failed to send reset email.");
       }
 
-      // Important: same message whether or not the account exists
       setStatus("If an account exists for that email, we sent a password reset link. Please check your inbox and spam.");
     } catch (err) {
       setError(err?.message || "Network error");
@@ -94,6 +93,7 @@ export default function FindPw() {
                 className="account-input"
                 placeholder="Email Address"
                 maxLength={254}
+                readOnly={!!status}
               />
               <div className="account-help-small">
                 You may need to check spam/junk. Some providers delay new senders by a few minutes.

--- a/src/pages/Community/myCommunity/MemberManage.css
+++ b/src/pages/Community/myCommunity/MemberManage.css
@@ -1,0 +1,302 @@
+.MemberManagePage {
+  background: #fdfcfa;
+  min-height: 100vh;
+}
+
+.MemberManageBody {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px 18px 50px;
+}
+
+.MemberManageHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.MemberManageTitle {
+  margin: 0;
+  font-size: 28px;
+}
+
+.MemberManageSub {
+  margin: 6px 0 0;
+}
+
+.MemberManageBack {
+  color: #3b3b3b;
+  text-decoration: underline;
+}
+
+.MemberManageTabsRow {
+  margin: 12px 0 10px;
+}
+
+.MemberManageTabs {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.TabBtn {
+  border: 1px solid #e7dfd4;
+  background: #fff;
+  border-radius: 999px;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.TabBtn:hover {
+  background: #faf7f2;
+}
+
+.TabBtn.active {
+  border-color: #111;
+  background: #111;
+  color: #fff;
+}
+
+.TabCount {
+  font-size: 12px;
+  padding: 1px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.TabBtn.active .TabCount {
+  border-color: rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.MemberManageError {
+  background: #ffe9e9;
+  color: #8a1f1f;
+  padding: 12px 14px;
+  border-radius: 10px;
+  margin: 10px 0 10px;
+  border: 1px solid #ffb7b7;
+}
+
+.MemberManageSuccess {
+  background: #eaf7ee;
+  color: #1e5b2b;
+  padding: 12px 14px;
+  border-radius: 10px;
+  margin: 10px 0 10px;
+  border: 1px solid #b8e7c4;
+}
+
+.MemberManageGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+@media (max-width: 900px) {
+  .MemberManageHeader {
+    flex-direction: column;
+  }
+
+  .MemberManageGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.Panel {
+  background: #fff;
+  border: 1px solid #ece6dd;
+  border-radius: 14px;
+  padding: 14px;
+}
+
+.PanelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.CountPill {
+  background: #f1ede6;
+  border: 1px solid #e7dfd4;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 13px;
+}
+
+.EmptyText {
+  margin: 10px 0 0;
+  color: #666;
+}
+
+.List {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.ListRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 0;
+  border-top: 1px solid #f0ebe2;
+}
+
+.ListRow:first-child {
+  border-top: none;
+}
+
+.RowMain {
+  min-width: 0;
+}
+
+.RowTitle {
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.RowSub {
+  font-size: 13px;
+  color: #666;
+  margin-top: 2px;
+  word-break: break-word;
+}
+
+.RowActions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.Btn {
+  border: 1px solid #d9d1c6;
+  background: #faf7f2;
+  padding: 8px 12px;
+  border-radius: 10px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.Btn:hover {
+  background: #f3eee6;
+}
+
+.Btn.danger {
+  border: 1px solid #ffb7b7;
+  background: #ffecec;
+  color: #8a1f1f;
+}
+
+.Btn.primary {
+  border: 1px solid #111;
+  background: #111;
+  color: #fff;
+}
+
+.Btn.primary:hover {
+  opacity: 0.92;
+}
+
+.RolePill {
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid #e4dccf;
+  background: #f4efe7;
+}
+
+.RolePill.owner {
+  border-color: #c9b06b;
+  background: #fff3d1;
+}
+
+.RolePill.leader {
+  border-color: #8db5d9;
+  background: #e9f3ff;
+}
+
+.MemberManageToggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #fff;
+  border: 1px solid #ece6dd;
+  border-radius: 14px;
+  padding: 10px 12px;
+}
+
+.ToggleLabel {
+  font-size: 13px;
+  color: #444;
+  max-width: 260px;
+}
+
+.ToggleBtn {
+  border-radius: 999px;
+  padding: 8px 12px;
+  cursor: pointer;
+  border: 1px solid #d9d1c6;
+  background: #faf7f2;
+}
+
+.ToggleBtn.on {
+  border-color: #8db5d9;
+  background: #e9f3ff;
+}
+
+.ToggleBtn.off {
+  border-color: #d9d1c6;
+  background: #faf7f2;
+}
+
+.InviteForm {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.InviteHint {
+  font-size: 13px;
+  color: #555;
+}
+
+.InviteRow {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+@media (max-width: 600px) {
+  .InviteRow {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+.InviteInput {
+  flex: 1;
+  border: 1px solid #d9d1c6;
+  background: #fff;
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-size: 14px;
+  outline: none;
+}
+
+.InviteInput:focus {
+  border-color: #111;
+}

--- a/src/pages/Community/myCommunity/MemberManage.js
+++ b/src/pages/Community/myCommunity/MemberManage.js
@@ -1,0 +1,471 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams, Link } from "react-router-dom";
+import PageHeader from "../../../component/PageHeader";
+import Footer from "../../../component/Footer";
+import { useAuth } from "../../../component/context/AuthContext";
+import { apiFetch } from "../../../component/utils/ApiFetch";
+import "./MemberManage.css";
+
+export default function MemberManage() {
+  const { communityId } = useParams();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+
+  const [community, setCommunity] = useState(null);
+  const [members, setMembers] = useState([]);
+  const [requests, setRequests] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState("");
+
+  const [activeTab, setActiveTab] = useState("requests");
+
+  const [inviteInput, setInviteInput] = useState("");
+  const [inviteSending, setInviteSending] = useState(false);
+  const [inviteMsg, setInviteMsg] = useState("");
+
+  const currentId = String(user?.id || user?._id || "");
+  const communityHomePath = `/community/${communityId}/my-posts`;
+
+  const leadersCanManageMembers = Boolean(community?.settings?.leadersCanManageMembers);
+
+  const isOwner = useMemo(() => {
+    const ownerId = String(community?.owner?.id || community?.owner?._id || "");
+    return ownerId && ownerId === currentId;
+  }, [community, currentId]);
+
+  const isLeader = useMemo(() => {
+    return (
+      Array.isArray(community?.members) &&
+      community.members.some(
+        (m) =>
+          (String(m.role || "").toLowerCase() === "leader" ||
+            String(m.role || "").toLowerCase() === "owner") &&
+          String(m.id || m._id || m.userId || "") === currentId
+      )
+    );
+  }, [community, currentId]);
+
+  const canManage = useMemo(() => {
+    return isOwner || (isLeader && leadersCanManageMembers);
+  }, [isOwner, isLeader, leadersCanManageMembers]);
+
+  const fetchCommunityOnly = useCallback(async () => {
+    const res = await apiFetch(`/community/${communityId}`);
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok || !data.ok) throw new Error(data.error || "Failed to load community.");
+    return data.community || null;
+  }, [communityId]);
+
+  const fetchMembersOnly = useCallback(async () => {
+    const res = await apiFetch(`/community/${communityId}/members`);
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok || !data.ok) throw new Error(data.error || "Failed to load members.");
+    return Array.isArray(data.members) ? data.members : [];
+  }, [communityId]);
+
+  const fetchRequestsOnly = useCallback(async () => {
+    const res = await apiFetch(`/community/${communityId}/join-requests`);
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok || !data.ok) throw new Error(data.error || "Failed to load join requests.");
+    return Array.isArray(data.requests) ? data.requests : [];
+  }, [communityId]);
+
+  const fetchAll = useCallback(async () => {
+    try {
+      setErr("");
+      setLoading(true);
+
+      const c = await fetchCommunityOnly();
+      setCommunity(c);
+
+      const ownerId = String(c?.owner?.id || c?.owner?._id || "");
+      const isOwnerNow = ownerId && ownerId === currentId;
+
+      const leadersAllowed = Boolean(c?.settings?.leadersCanManageMembers);
+      const isLeaderNow =
+        Array.isArray(c?.members) &&
+        c.members.some(
+          (m) =>
+            (String(m.role || "").toLowerCase() === "leader" ||
+              String(m.role || "").toLowerCase() === "owner") &&
+            String(m.id || m._id || m.userId || "") === currentId
+        );
+
+      const canManageNow = isOwnerNow || (isLeaderNow && leadersAllowed);
+
+      if (!canManageNow) {
+        setMembers([]);
+        setRequests([]);
+        navigate(communityHomePath, { replace: true });
+        return;
+      }
+
+      const [m, r] = await Promise.all([fetchMembersOnly(), fetchRequestsOnly()]);
+      setMembers(m);
+      setRequests(r);
+    } catch (e) {
+      setErr(e.message || "Failed to load member management.");
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    communityId,
+    currentId,
+    navigate,
+    communityHomePath,
+    fetchCommunityOnly,
+    fetchMembersOnly,
+    fetchRequestsOnly,
+  ]);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  useEffect(() => {
+    if (!canManage) return;
+    if (activeTab === "invite" && !(isOwner || (isLeader && leadersCanManageMembers))) {
+      setActiveTab("requests");
+    }
+  }, [activeTab, canManage, isOwner, isLeader, leadersCanManageMembers]);
+
+  const toggleLeadersRule = async () => {
+    if (!isOwner) return;
+
+    try {
+      setErr("");
+      const res = await apiFetch(`/community/${communityId}/settings`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          leadersCanManageMembers: !leadersCanManageMembers,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || !data.ok) throw new Error(data.error || "Failed to update setting.");
+
+      setCommunity((prev) => data.community || prev);
+    } catch (e) {
+      setErr(e.message || "Failed to update setting.");
+    }
+  };
+
+  const acceptRequest = async (requestUserId) => {
+    try {
+      setErr("");
+      const res = await apiFetch(
+        `/community/${communityId}/join-requests/${requestUserId}/accept`,
+        { method: "POST" }
+      );
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || !data.ok) throw new Error(data.error || "Failed to accept request.");
+      await fetchAll();
+    } catch (e) {
+      setErr(e.message || "Failed to accept request.");
+    }
+  };
+
+  const rejectRequest = async (requestUserId) => {
+    try {
+      setErr("");
+      const res = await apiFetch(
+        `/community/${communityId}/join-requests/${requestUserId}/reject`,
+        { method: "POST" }
+      );
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || !data.ok) throw new Error(data.error || "Failed to reject request.");
+      await fetchAll();
+    } catch (e) {
+      setErr(e.message || "Failed to reject request.");
+    }
+  };
+
+  const expelMember = async (memberUserId) => {
+    const ok = window.confirm("Expel this member? They will be removed from the community.");
+    if (!ok) return;
+
+    try {
+      setErr("");
+      const res = await apiFetch(`/community/${communityId}/members/${memberUserId}`, {
+        method: "DELETE",
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || !data.ok) throw new Error(data.error || "Failed to expel member.");
+      await fetchAll();
+    } catch (e) {
+      setErr(e.message || "Failed to expel member.");
+    }
+  };
+
+  const promoteToLeader = async (memberUserId) => {
+    if (!isOwner) return;
+    try {
+      setErr("");
+      const res = await apiFetch(`/community/${communityId}/members/${memberUserId}/role`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role: "Leader" }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || !data.ok) throw new Error(data.error || "Failed to promote.");
+      await fetchAll();
+    } catch (e) {
+      setErr(e.message || "Failed to promote.");
+    }
+  };
+
+  const demoteToMember = async (memberUserId) => {
+    if (!isOwner) return;
+    try {
+      setErr("");
+      const res = await apiFetch(`/community/${communityId}/members/${memberUserId}/role`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role: "Member" }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || !data.ok) throw new Error(data.error || "Failed to demote.");
+      await fetchAll();
+    } catch (e) {
+      setErr(e.message || "Failed to demote.");
+    }
+  };
+
+  const canSeeInviteTab = isOwner || (isLeader && leadersCanManageMembers);
+
+  const sendInvite = async () => {
+    if (!canSeeInviteTab) return;
+
+    const identifier = String(inviteInput || "").trim();
+    if (!identifier) return;
+
+    try {
+      setErr("");
+      setInviteMsg("");
+      setInviteSending(true);
+
+      const res = await apiFetch(`/community/${communityId}/invite`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ identifier }),
+      });
+
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || !data.ok) throw new Error(data.error || "Failed to send invitation.");
+
+      setInviteInput("");
+      setInviteMsg("Invitation sent.");
+    } catch (e) {
+      setErr(e.message || "Failed to send invitation.");
+    } finally {
+      setInviteSending(false);
+    }
+  };
+
+  const onInviteKeyDown = (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (!inviteSending) sendInvite();
+    }
+  };
+
+  if (loading) {
+    return (
+      <section className="MemberManagePage">
+        <PageHeader />
+        <div className="MemberManageBody">Loading…</div>
+        <Footer />
+      </section>
+    );
+  }
+
+  return (
+    <section className="MemberManagePage">
+      <PageHeader />
+
+      <div className="MemberManageBody">
+        <div className="MemberManageHeader">
+          <div className="MemberManageHeaderLeft">
+            <h1 className="MemberManageTitle">Manage Members</h1>
+            <p className="MemberManageSub">
+              <Link to={communityHomePath} className="MemberManageBack">
+                ← Back to community
+              </Link>
+            </p>
+          </div>
+
+          {isOwner && (
+            <div className="MemberManageToggle">
+              <div className="ToggleLabel">Allow leaders to accept/expel & invite</div>
+              <button
+                type="button"
+                className={`ToggleBtn ${leadersCanManageMembers ? "on" : "off"}`}
+                onClick={toggleLeadersRule}
+              >
+                {leadersCanManageMembers ? "On" : "Off"}
+              </button>
+            </div>
+          )}
+        </div>
+
+        <div className="MemberManageTabsRow">
+          <div className="MemberManageTabs">
+            <button
+              type="button"
+              className={`TabBtn ${activeTab === "requests" ? "active" : ""}`}
+              onClick={() => setActiveTab("requests")}
+            >
+              Join Requests <span className="TabCount">{requests.length}</span>
+            </button>
+
+            <button
+              type="button"
+              className={`TabBtn ${activeTab === "members" ? "active" : ""}`}
+              onClick={() => setActiveTab("members")}
+            >
+              Members <span className="TabCount">{members.length}</span>
+            </button>
+
+            {canSeeInviteTab && (
+              <button
+                type="button"
+                className={`TabBtn ${activeTab === "invite" ? "active" : ""}`}
+                onClick={() => setActiveTab("invite")}
+              >
+                Invitations
+              </button>
+            )}
+          </div>
+        </div>
+
+        {err && <div className="MemberManageError">{err}</div>}
+        {inviteMsg && <div className="MemberManageSuccess">{inviteMsg}</div>}
+
+        {activeTab === "invite" && canSeeInviteTab && (
+          <div className="Panel">
+            <div className="PanelHeader">
+              <h2>Send Invitation</h2>
+            </div>
+
+            <div className="InviteForm">
+              <div className="InviteHint">Enter a username or email address.</div>
+
+              <div className="InviteRow">
+                <input
+                  className="InviteInput"
+                  value={inviteInput}
+                  onChange={(e) => setInviteInput(e.target.value)}
+                  onKeyDown={onInviteKeyDown}
+                  placeholder="username or email"
+                  disabled={inviteSending}
+                />
+                <button
+                  type="button"
+                  className="Btn primary"
+                  onClick={sendInvite}
+                  disabled={inviteSending || !String(inviteInput || "").trim()}
+                >
+                  {inviteSending ? "Sending…" : "Send"}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {activeTab !== "invite" && (
+          <div className="MemberManageGrid">
+            <div className="Panel">
+              <div className="PanelHeader">
+                <h2>Join Requests</h2>
+                <span className="CountPill">{requests.length}</span>
+              </div>
+
+              {requests.length === 0 ? (
+                <p className="EmptyText">No pending requests.</p>
+              ) : (
+                <ul className="List">
+                  {requests.map((r) => {
+                    const uid = String(r.userId || r.id || r._id || "");
+                    return (
+                      <li key={uid} className="ListRow">
+                        <div className="RowMain">
+                          <div className="RowTitle">{r.name || r.email || uid}</div>
+                          <div className="RowSub">{r.email || ""}</div>
+                        </div>
+
+                        <div className="RowActions">
+                          <button className="Btn" onClick={() => acceptRequest(uid)}>
+                            Accept
+                          </button>
+                          <button className="Btn danger" onClick={() => rejectRequest(uid)}>
+                            Reject
+                          </button>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+
+            <div className="Panel">
+              <div className="PanelHeader">
+                <h2>Members</h2>
+                <span className="CountPill">{members.length}</span>
+              </div>
+
+              {members.length === 0 ? (
+                <p className="EmptyText">No members found.</p>
+              ) : (
+                <ul className="List">
+                  {members.map((m) => {
+                    const uid = String(m.userId || m.id || m._id || "");
+                    const role = String(m.role || "Member");
+                    const isSelf = uid === currentId;
+                    const isOwnerRow = role.toLowerCase() === "owner";
+
+                    return (
+                      <li key={uid} className="ListRow">
+                        <div className="RowMain">
+                          <div className="RowTitle">
+                            {m.name || m.email || uid}{" "}
+                            <span className={`RolePill ${role.toLowerCase()}`}>{role}</span>
+                          </div>
+                          <div className="RowSub">{m.email || ""}</div>
+                        </div>
+
+                        <div className="RowActions">
+                          {isOwner && !isOwnerRow && (
+                            <>
+                              {role.toLowerCase() !== "leader" ? (
+                                <button className="Btn" onClick={() => promoteToLeader(uid)}>
+                                  Promote
+                                </button>
+                              ) : (
+                                <button className="Btn" onClick={() => demoteToMember(uid)}>
+                                  Demote
+                                </button>
+                              )}
+                            </>
+                          )}
+
+                          {!isOwnerRow && !isSelf && (
+                            <button className="Btn danger" onClick={() => expelMember(uid)}>
+                              Expel
+                            </button>
+                          )}
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <Footer />
+    </section>
+  );
+}

--- a/src/pages/Community/myCommunity/MyCommunity.css
+++ b/src/pages/Community/myCommunity/MyCommunity.css
@@ -33,6 +33,23 @@
   padding-top: 20px;
   display: flex;
   justify-content: end;
+  gap: 10px;
+  align-items: center;
+}
+
+.ManageButton {
+  background: transparent;
+  color: #000;
+  font-size: 16px;
+  padding: 10px 18px;
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.55);
+  cursor: pointer;
+  margin-bottom: 24px;
+}
+
+.ManageButton:hover {
+  background: rgba(0, 0, 0, 0.06);
 }
 
 .ForumHero {

--- a/src/pages/Community/myCommunity/MyCommunity.js
+++ b/src/pages/Community/myCommunity/MyCommunity.js
@@ -218,13 +218,18 @@ const MyCommunity = () => {
     if (!community || !user) return false;
 
     const currentId = user.id || user._id;
-    const isOwner = community.owner && (community.owner.id === currentId || community.owner._id === currentId);
+    const isOwnerLocal =
+      community.owner && (community.owner.id === currentId || community.owner._id === currentId);
 
-    const isLeader =
+    const isLeaderLocal =
       Array.isArray(community.members) &&
-      community.members.some((m) => (m.role === "Leader" || m.role === "Owner") && (m.id === currentId || m._id === currentId));
+      community.members.some(
+        (m) =>
+          (m.role === "Leader" || m.role === "Owner") &&
+          (m.id === currentId || m._id === currentId)
+      );
 
-    return isOwner || isLeader;
+    return isOwnerLocal || isLeaderLocal;
   })();
 
   const orderedPosts = useMemo(() => {
@@ -257,7 +262,6 @@ const MyCommunity = () => {
     },
     [currentUserId, canModeratePosts]
   );
-
 
   const handleDeletePost = useCallback(
     async (postId) => {
@@ -293,6 +297,33 @@ const MyCommunity = () => {
     },
     [communityId, deletingPostId]
   );
+
+  const isOwner = useMemo(() => {
+    const ownerId = String(community?.owner?.id || community?.owner?._id || "");
+    return ownerId && ownerId === currentUserId;
+  }, [community, currentUserId]);
+
+  const isLeader = useMemo(() => {
+    return (
+      Array.isArray(community?.members) &&
+      community.members.some(
+        (m) =>
+          (String(m.role || "").toLowerCase() === "leader" ||
+            String(m.role || "").toLowerCase() === "owner") &&
+          String(m.id || m._id || "") === currentUserId
+      )
+    );
+  }, [community, currentUserId]);
+
+  const leadersCanManageMembers = Boolean(community?.settings?.leadersCanManageMembers);
+
+  const canManageMembers = useMemo(() => {
+    return isOwner || (isLeader && leadersCanManageMembers);
+  }, [isOwner, isLeader, leadersCanManageMembers]);
+
+  const handleManageMembersClick = () => {
+    navigate(`/community/${communityId}/members/manage`);
+  };
 
   return (
     <section className="ForumContainer">
@@ -333,6 +364,11 @@ const MyCommunity = () => {
 
       <section className="ForumBody">
         <div className="ForumActions">
+          {canManageMembers && (
+            <button className="ManageButton" onClick={handleManageMembersClick}>
+              Manage
+            </button>
+          )}
           <button className="NewPostButton" onClick={handleNewPostClick}>
             New Post
           </button>
@@ -357,11 +393,7 @@ const MyCommunity = () => {
             </thead>
             <tbody>
               {orderedPosts.map((post) => (
-                <tr
-                  key={post.id}
-                  className="ForumRow"
-                  onClick={() => handleRowClick(post.id)}
-                >
+                <tr key={post.id} className="ForumRow" onClick={() => handleRowClick(post.id)}>
                   <td className="topic">
                     <div className="title">{post.title}</div>
                     <div className="subtitle">{post.subtitle}</div>
@@ -371,10 +403,8 @@ const MyCommunity = () => {
                   </td>
                   <td>{post.replyCount}</td>
                   <td>{formatActivity(post)}</td>
-                  {/* Forum delete / edit section */}
                   <td
-                    className={`ForumActionsCell ${canEditOrDeletePost(post) ? "can-delete" : ""
-                      }`}
+                    className={`ForumActionsCell ${canEditOrDeletePost(post) ? "can-delete" : ""}`}
                     onClick={(e) => e.stopPropagation()}
                   >
                     {canEditOrDeletePost(post) && (


### PR DESCRIPTION
Added community settings flag leadersCanManageMembers (default false) to control leader moderation powers

Implemented member management API endpoints: list members, expel member, promote/demote roles (owner-only), and update settings (owner-only)

Added invite flow that allows owners (and permitted leaders) to send invitations using username or email

Updated community detail payload to include settings and member role summaries for permission checks in UI