### PR TITLE
Refactor community post notifications with per-type dedupe and cascade handling

### DIFF
--- a/src/pages/Account/Account.js
+++ b/src/pages/Account/Account.js
@@ -138,10 +138,10 @@ export default function Account() {
 
           <div className="account-signup-findpw">
             <p className="account-help">
-              아직 계정이 없나요? <a href="/signup">회원가입</a>
+              Don’t have an account yet? <a href="/signup">Sign up</a>
             </p>
             <p className="account-help">
-              <a href="/findpw">비밀번호를 잊었습니까?</a>
+              <a href="/findpw">Forgot your password?</a>
             </p>
           </div>
         </div>

--- a/src/pages/Account/signUp/SignUp.js
+++ b/src/pages/Account/signUp/SignUp.js
@@ -236,7 +236,7 @@ const SignUp = () => {
 
     if (!isValid) {
       focusFirstInvalid();
-      setError("입력값을 확인해주세요.");
+      setError("Please check your information.");
       return;
     }
 
@@ -259,7 +259,7 @@ const SignUp = () => {
       const data = await res.json().catch(() => ({}));
 
       if (!res.ok || data?.ok === false) {
-        throw new Error(data?.error || "회원가입 실패");
+        throw new Error(data?.error || "Sign up failed.");
       }
 
       navigate("/check-email", {
@@ -267,7 +267,7 @@ const SignUp = () => {
         state: { email: emailValue, sent: data?.verification?.sent ?? true },
       });
     } catch (err) {
-      setError(err.message || "네트워크 오류");
+      setError(err.message || "Network error.");
     } finally {
       setLoading(false);
     }
@@ -448,10 +448,10 @@ const SignUp = () => {
 
           <div className="account-signup-findpw">
             <p className="account-help">
-              이미 계정이 있나요? <a href="/account">로그인</a>
+              Already have an account? <a href="/account">Sign in</a>
             </p>
             <p className="account-help">
-              <a href="/findpw">비밀번호를 잊었습니까?</a>
+              <a href="/findpw">Forgot your password?</a>
             </p>
           </div>
         </div>

--- a/src/pages/Account/userMenu/Notifications.js
+++ b/src/pages/Account/userMenu/Notifications.js
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from "react";
+import { useNavigate } from "react-router-dom";
 import PageHeader from "../../../component/PageHeader";
 import Footer from "../../../component/Footer";
 import { useNotifications } from "../../../component/context/NotificationContext";
@@ -9,6 +10,7 @@ import { apiFetch, getApiBase } from "../../../component/utils/ApiFetch";
 const REQUEST_TIMEOUT_MS = 10000;
 
 const Notifications = () => {
+  const navigate = useNavigate();
   const { refreshUnreadCount } = useNotifications();
 
   const [notifications, setNotifications] = useState([]);
@@ -52,7 +54,6 @@ const Notifications = () => {
     setError("");
 
     try {
-      // helpful debug: confirms what base URL you are ACTUALLY calling
       console.log("[Notifications] API_BASE =", getApiBase());
       console.log("[Notifications] GET /notifications");
 
@@ -126,6 +127,51 @@ const Notifications = () => {
     } catch (e) {
       console.error("[notification delete-one error]", e);
       setError(e?.message || "Failed to delete notification");
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  async function handleOpenNotification(n) {
+    const id = n?._id || n?.id;
+    if (!id) return;
+    if (bulkLoading || deletingId || actingId) return;
+
+    const communityId = n?.community ? String(n.community) : "";
+    const postId =
+      n?.target?.kind === "COMMUNITY_POST" && n?.target?.id ? String(n.target.id) : "";
+
+    // Navigate first (feels snappy), then delete in background.
+    if (n?.type === "COMMUNITY_NEW_POST" && communityId && postId) {
+      navigate(`/community/${communityId}/posts/${postId}`);
+    }
+
+    // Cascade delete by community when possible, otherwise delete just one.
+    try {
+      setDeletingId(id);
+      setError("");
+
+      const url =
+        communityId ? `/notifications/${id}?cascade=community` : `/notifications/${id}`;
+
+      const res = await fetchWithTimeout(url, { method: "DELETE" });
+      const data = await safeJson(res);
+
+      if (!res.ok || !data?.ok) {
+        throw new Error(data?.error || `Failed to delete notification (${res.status})`);
+      }
+
+      setNotifications((prev) => {
+        if (communityId) {
+          return prev.filter((x) => String(x?.community || "") !== communityId);
+        }
+        return prev.filter((x) => (x?._id || x?.id) !== id);
+      });
+
+      refreshUnreadCount();
+    } catch (e) {
+      console.error("[notification open+delete error]", e);
+      setError(e?.message || "Failed to remove notification");
     } finally {
       setDeletingId(null);
     }
@@ -250,7 +296,15 @@ const Notifications = () => {
                 return (
                   <li
                     key={id}
-                    className={`notification-item ${isUnread(n) ? "notification-item--unread" : ""}`}
+                    className={`notification-item ${
+                      isUnread(n) ? "notification-item--unread" : ""
+                    }`}
+                    onClick={() => handleOpenNotification(n)}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") handleOpenNotification(n);
+                    }}
                   >
                     <div className="notification-main">
                       <div className="notification-title">{n?.message}</div>
@@ -262,7 +316,10 @@ const Notifications = () => {
                       </span>
 
                       {pending && (
-                        <div className="notification-actions">
+                        <div
+                          className="notification-actions"
+                          onClick={(e) => e.stopPropagation()}
+                        >
                           <button
                             type="button"
                             className="notification-action-btn"
@@ -285,7 +342,10 @@ const Notifications = () => {
                       <button
                         type="button"
                         className="notification-delete-btn"
-                        onClick={() => handleDeleteOne(id)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDeleteOne(id);
+                        }}
                         disabled={deletingId === id || bulkLoading}
                         aria-label="Delete notification"
                         title="Delete notification"

--- a/src/pages/Community/communityTypes/bibleStudy.js
+++ b/src/pages/Community/communityTypes/bibleStudy.js
@@ -1,13 +1,13 @@
 const bibleStudy = {
-  key: "general",
+  key: "bible_study",
   label: "📖 Bible Study",
-  tagClass: "general",
-  apiValue: "general",
+  apiValue: "bible_study",
+  className: "bible_study",
   isPoll: false,
   matches: (post) => {
     const type = String(post?.type || "").toLowerCase();
-    const category = String(post?.category || "").toLowerCase();
-    return type === "general" || category === "general";
+    const categoryClass = String(post?.categoryClass || "").toLowerCase();
+    return type === "bible_study" || categoryClass === "bible_study";
   },
 };
 

--- a/src/pages/Community/communityTypes/index.js
+++ b/src/pages/Community/communityTypes/index.js
@@ -24,7 +24,7 @@ export const getTypeLabel = (post) => getTypeForPost(post).label;
 
 export const getTypeTagClass = (post) => {
   const t = getTypeForPost(post);
-  return post?.categoryClass || t.tagClass || "general";
+  return post?.categoryClass || t.tagClass || "bible_study";
 };
 
 const toTime = (v) => {

--- a/src/pages/Community/myCommunity/MyCommunity.css
+++ b/src/pages/Community/myCommunity/MyCommunity.css
@@ -6,7 +6,7 @@
   flex-direction: column;
 }
 
-.ForumContainer > :last-child {
+.ForumContainer> :last-child {
   margin-top: auto;
 }
 
@@ -343,7 +343,7 @@
   cursor: default;
 }
 
-.Tag.general {
+.Tag.bible_study {
   background: #c8d1b2;
 }
 

--- a/src/pages/Community/myCommunity/MyCommunity.js
+++ b/src/pages/Community/myCommunity/MyCommunity.js
@@ -117,10 +117,9 @@ const MyCommunity = () => {
     try {
       setNewPostError("");
 
-      if (
-        String(newPostPayload?.typeValue || "").toLowerCase() === "announcements" &&
-        announcementCount >= MAX_ANNOUNCEMENTS_PER_COMMUNITY
-      ) {
+      const payloadType = String(newPostPayload?.type || newPostPayload?.typeValue || "").toLowerCase();
+
+      if (payloadType === "announcements" && announcementCount >= MAX_ANNOUNCEMENTS_PER_COMMUNITY) {
         const message = `This community already has ${MAX_ANNOUNCEMENTS_PER_COMMUNITY} announcements.`;
         setNewPostError(message);
         return { ok: false, message };
@@ -130,10 +129,10 @@ const MyCommunity = () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          title: newPostPayload.title,
-          body: newPostPayload.description,
-          type: newPostPayload.typeValue,
-          poll: newPostPayload.poll,
+          title: newPostPayload?.title,
+          body: newPostPayload?.body,
+          type: newPostPayload?.type || newPostPayload?.typeValue || "bible_study",
+          poll: newPostPayload?.poll,
         }),
       });
 

--- a/src/pages/Community/myCommunity/NewPost.js
+++ b/src/pages/Community/myCommunity/NewPost.js
@@ -8,7 +8,7 @@ const NewPostModal = ({ onClose, onSubmit, announcementCount = 0 }) => {
   const typeOptions = useMemo(() => COMMUNITY_TYPES, []);
 
   const [title, setTitle] = useState("");
-  const [type, setType] = useState(typeOptions[0]?.apiValue || "general");
+  const [type, setType] = useState(typeOptions[0]?.apiValue || "bible_study");
   const [description, setDescription] = useState("");
 
   const [pollOptions, setPollOptions] = useState(["", ""]);
@@ -29,30 +29,29 @@ const NewPostModal = ({ onClose, onSubmit, announcementCount = 0 }) => {
     setGlobalError("");
     setErrors({});
 
-    if (!title.trim()) {
+    const cleanTitle = title.trim();
+    const cleanBody = description.trim();
+    const cleanType = selectedType?.apiValue || "bible_study";
+
+    if (!cleanTitle) {
       setGlobalError("Title is required.");
       return;
     }
 
-    if (
-      selectedType?.apiValue === "announcements" &&
-      announcementCount >= MAX_ANNOUNCEMENTS_PER_COMMUNITY
-    ) {
+    if (cleanType === "announcements" && announcementCount >= MAX_ANNOUNCEMENTS_PER_COMMUNITY) {
       setGlobalError(`This community already has ${MAX_ANNOUNCEMENTS_PER_COMMUNITY} announcements.`);
       return;
     }
 
-    if (!isPoll && !description.trim()) {
+    if (!isPoll && !cleanBody) {
       setGlobalError("Description is required.");
       return;
     }
 
     let payload = {
-      title: title.trim(),
-      description: description.trim(),
-      typeValue: selectedType?.apiValue || "general",
-      typeLabel: selectedType?.label || "General",
-      typeClass: selectedType?.className || "general",
+      title: cleanTitle,
+      body: cleanBody,
+      type: cleanType,
     };
 
     if (isPoll) {
@@ -80,9 +79,7 @@ const NewPostModal = ({ onClose, onSubmit, announcementCount = 0 }) => {
   };
 
   const handleOverlayClick = (e) => {
-    if (e.target.classList.contains("NewPostOverlay")) {
-      onClose?.();
-    }
+    if (e.target.classList.contains("NewPostOverlay")) onClose?.();
   };
 
   const handlePollOptionChange = (index, value) => {
@@ -93,9 +90,7 @@ const NewPostModal = ({ onClose, onSubmit, announcementCount = 0 }) => {
     });
   };
 
-  const handleAddPollOption = () => {
-    setPollOptions((prev) => [...prev, ""]);
-  };
+  const handleAddPollOption = () => setPollOptions((prev) => [...prev, ""]);
 
   const handleRemovePollOption = (index) => {
     setPollOptions((prev) => {
@@ -140,22 +135,14 @@ const NewPostModal = ({ onClose, onSubmit, announcementCount = 0 }) => {
 
           <div className="NewPostField">
             <label htmlFor="post-type">Post type</label>
-            <select
-              id="post-type"
-              value={type}
-              onChange={(e) => setType(e.target.value)}
-            >
+            <select id="post-type" value={type} onChange={(e) => setType(e.target.value)}>
               {typeOptions.map((option) => {
                 const isAnnouncements = option.apiValue === "announcements";
                 const disabled =
                   isAnnouncements && announcementCount >= MAX_ANNOUNCEMENTS_PER_COMMUNITY;
 
                 return (
-                  <option
-                    key={option.apiValue}
-                    value={option.apiValue}
-                    disabled={disabled}
-                  >
+                  <option key={option.apiValue} value={option.apiValue} disabled={disabled}>
                     {option.label}
                     {disabled ? " (limit reached)" : ""}
                   </option>
@@ -196,17 +183,11 @@ const NewPostModal = ({ onClose, onSubmit, announcementCount = 0 }) => {
                   ))}
                 </div>
 
-                <button
-                  type="button"
-                  className="PollAddOptionButton"
-                  onClick={handleAddPollOption}
-                >
+                <button type="button" className="PollAddOptionButton" onClick={handleAddPollOption}>
                   + Add option
                 </button>
 
-                {errors.pollOptions && (
-                  <div className="NewPostErrorText">{errors.pollOptions}</div>
-                )}
+                {errors.pollOptions && <div className="NewPostErrorText">{errors.pollOptions}</div>}
               </div>
 
               <div className="NewPostField PollSettingsField">
@@ -234,9 +215,7 @@ const NewPostModal = ({ onClose, onSubmit, announcementCount = 0 }) => {
           )}
 
           <div className="NewPostField">
-            <label htmlFor="post-description">
-              {isPoll ? "Description (optional)" : "Description"}
-            </label>
+            <label htmlFor="post-description">{isPoll ? "Description (optional)" : "Description"}</label>
             <textarea
               id="post-description"
               rows={5}
@@ -252,11 +231,7 @@ const NewPostModal = ({ onClose, onSubmit, announcementCount = 0 }) => {
           </div>
 
           <div className="NewPostActions">
-            <button
-              type="button"
-              className="NewPostSecondaryButton"
-              onClick={onClose}
-            >
+            <button type="button" className="NewPostSecondaryButton" onClick={onClose}>
               Cancel
             </button>
             <button type="submit" className="NewPostPrimaryButton">


### PR DESCRIPTION
- Send COMMUNITY_NEW_POST notifications with formatted message:
  "{AuthorName} posted a new {PostType} post in {CommunityName}."
- Notify all members for announcements and bible_study; owners/leaders only for questions
- Enforce one notification per community + post type using dedupeKey
- Add cascade delete support in notifications route (?cascade=community)
- Clicking notification navigates to post and removes related community notifications
- Align frontend payload to use { title, body, type } consistently
- Remove legacy "general" post type