### PR TITLE
feat: add about walkthroughs and fix profile navigation issues

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -46,7 +46,7 @@ h3 {
   /* mobile drawer width */
   --drawer-max: 420px;
   /* max width */
-  --backdrop: rgba(0, 0, 0, .5);
+  --backdrop: rgba(0, 0, 0, .68);
 }
 
 /* Footer */
@@ -189,15 +189,23 @@ h3 {
 /* =================================================================
    ≤ 768px — MOBILE SIDEBAR DRAWER (fills width inside the drawer)
    ================================================================= */
-@media (max-width: 768px) {
+@media (max-width: 940px) {
 
-  /* show burger / hide inline menu */
+  /* keep inline nav mounted for the profile button only */
   .MenuInline {
-    display: none;
+    display: flex;
   }
 
   .Hamburger {
     display: flex;
+  }
+
+  .MenuInline .MenuOptions {
+    padding-right: 0;
+  }
+
+  .MenuInline .MenuOptions > li:not(.UserMenuWrapper) {
+    display: none;
   }
 
   /* Drawer panel (right) */

--- a/src/App.js
+++ b/src/App.js
@@ -36,8 +36,15 @@ import CommunityBibleStudyComposer from "./pages/Community/myCommunity/bibleStud
 import BibleStudyShare from "./pages/Community/myCommunity/postDetail/BibleStudyShare";
 import RequireAuth from "./component/routes/RequireAuth";
 import RequireCommunityAccess from "./component/routes/RequireCommunityAccess";
+import MobileUnavailable, { useIsMobileViewport } from "./component/MobileUnavailable";
 
 function App() {
+  const isMobileViewport = useIsMobileViewport();
+
+  if (isMobileViewport) {
+    return <MobileUnavailable />;
+  }
+
   return (
     <div className="App">
       <BrowserRouter>

--- a/src/component/Header.css
+++ b/src/component/Header.css
@@ -15,11 +15,16 @@
   min-height: var(--header-h);
 }
 
-/* Make room for wrapped menus on tablets */
-@media (max-width: 992px) {
+/* Switch to compact header layout when drawer navigation takes over */
+@media (max-width: 940px) {
   .Header {
-    flex-wrap: wrap;
-    row-gap: 8px;
+    flex-wrap: nowrap;
+    row-gap: 0;
+    justify-content: flex-start;
+  }
+
+  .Header .MenuInline {
+    margin-left: auto;
   }
 }
 
@@ -57,6 +62,10 @@
 
 .MenuInline {
   display: flex;
+}
+
+.Hamburger {
+  margin-left: 0;
 }
 
 .MenuOptions {

--- a/src/component/MobileUnavailable.css
+++ b/src/component/MobileUnavailable.css
@@ -1,0 +1,60 @@
+.MobileUnavailable {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 22px;
+  background:
+    radial-gradient(circle at top, rgba(250, 225, 189, 0.95), rgba(244, 236, 224, 0.98) 38%, #f4ede3 100%);
+}
+
+.MobileUnavailableCard {
+  width: min(100%, 460px);
+  padding: 38px 30px 40px;
+  border-radius: 32px;
+  background: rgba(255, 250, 243, 0.96);
+  border: 1px solid rgba(127, 90, 54, 0.14);
+  box-shadow: 0 18px 48px rgba(71, 45, 25, 0.12);
+  text-align: center;
+}
+
+.MobileUnavailableIllustration {
+  width: min(100%, 260px);
+  margin: 0 auto 22px;
+}
+
+.MobileUnavailableIllustration svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.MobileUnavailableEyebrow {
+  margin: 0 0 14px;
+  color: #8f6840;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.MobileUnavailableTitle {
+  margin: 0 0 16px;
+  color: #2d2018;
+  font-size: clamp(2.15rem, 8vw, 2.7rem);
+  line-height: 1.02;
+}
+
+.MobileUnavailableMessage {
+  margin: 0 0 14px;
+  color: #4d3929;
+  font-size: 1.08rem;
+  line-height: 1.72;
+}
+
+.MobileUnavailableNote {
+  margin: 0;
+  color: #7b624d;
+  font-size: 1rem;
+  line-height: 1.65;
+}

--- a/src/component/MobileUnavailable.js
+++ b/src/component/MobileUnavailable.js
@@ -1,0 +1,100 @@
+import { useEffect, useState } from "react";
+import "./MobileUnavailable.css";
+
+const MOBILE_QUERY = "(max-width: 768px)";
+
+const getIsMobile = () => {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+
+  return window.matchMedia(MOBILE_QUERY).matches;
+};
+
+export const useIsMobileViewport = () => {
+  const [isMobile, setIsMobile] = useState(getIsMobile);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return undefined;
+
+    const mediaQuery = window.matchMedia(MOBILE_QUERY);
+    const handleChange = (event) => setIsMobile(event.matches);
+
+    setIsMobile(mediaQuery.matches);
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange);
+      return () => mediaQuery.removeEventListener("change", handleChange);
+    }
+
+    mediaQuery.addListener(handleChange);
+    return () => mediaQuery.removeListener(handleChange);
+  }, []);
+
+  return isMobile;
+};
+
+const MobileUnavailable = () => {
+  return (
+    <section className="MobileUnavailable">
+      <div className="MobileUnavailableCard">
+        <div className="MobileUnavailableIllustration" aria-hidden="true">
+          <svg viewBox="0 0 320 240" role="img">
+            <title>Cartoon Bible illustration</title>
+            <ellipse cx="160" cy="210" rx="88" ry="16" fill="rgba(126, 86, 47, 0.18)" />
+            <circle cx="78" cy="56" r="18" fill="#fff7ea" />
+            <circle cx="102" cy="48" r="14" fill="#fff7ea" />
+            <circle cx="125" cy="58" r="18" fill="#fff7ea" />
+            <circle cx="238" cy="60" r="16" fill="#fff7ea" />
+            <circle cx="258" cy="50" r="13" fill="#fff7ea" />
+            <circle cx="278" cy="60" r="16" fill="#fff7ea" />
+            <path d="M140 26c8 12 8 21 0 31c-8-10-8-19 0-31Z" fill="#f8d88c" />
+            <path d="M140 24v34" stroke="#d5a84c" strokeWidth="4" strokeLinecap="round" />
+            <path
+              d="M86 96c0-18 14-32 32-32h84c18 0 32 14 32 32v70c0 18-14 32-32 32h-84c-18 0-32-14-32-32Z"
+              fill="#d39a5f"
+            />
+            <path
+              d="M104 90c0-14 11-25 25-25h62c14 0 25 11 25 25v72c0 14-11 25-25 25h-62c-14 0-25-11-25-25Z"
+              fill="#8a5a33"
+            />
+            <path d="M160 88v56" stroke="#f6e8c9" strokeWidth="10" strokeLinecap="round" />
+            <path d="M132 116h56" stroke="#f6e8c9" strokeWidth="10" strokeLinecap="round" />
+            <path
+              d="M110 164c10-10 24-16 50-16s40 6 50 16v25H110Z"
+              fill="#fff6e4"
+            />
+            <circle cx="134" cy="122" r="6" fill="#2d2018" />
+            <circle cx="186" cy="122" r="6" fill="#2d2018" />
+            <path d="M140 142c10 10 30 10 40 0" stroke="#2d2018" strokeWidth="5" strokeLinecap="round" fill="none" />
+            <path d="M107 153c-10 8-16 16-20 27" stroke="#8a5a33" strokeWidth="7" strokeLinecap="round" fill="none" />
+            <path d="M213 153c10 8 16 16 20 27" stroke="#8a5a33" strokeWidth="7" strokeLinecap="round" fill="none" />
+            <path d="M132 198v-20" stroke="#8a5a33" strokeWidth="8" strokeLinecap="round" />
+            <path d="M188 198v-20" stroke="#8a5a33" strokeWidth="8" strokeLinecap="round" />
+            <path
+              d="M255 102c8-10 16-10 24 0c-8 10-16 10-24 0Z"
+              fill="#fff7ea"
+            />
+            <path
+              d="M273 98c10-10 18-10 26 0c-8 10-16 10-26 0Z"
+              fill="#fff7ea"
+            />
+          </svg>
+        </div>
+
+        <p className="MobileUnavailableEyebrow">Verse By Verse</p>
+        <h1 className="MobileUnavailableTitle">Mobile view unavailable</h1>
+        <p className="MobileUnavailableMessage">
+          Our app is coming.
+          <br />
+          And it will be worth the wait.
+        </p>
+        <p className="MobileUnavailableNote">
+          For now, please visit on a desktop or larger screen.
+        </p>
+      </div>
+    </section>
+  );
+};
+
+export default MobileUnavailable;

--- a/src/component/PageHeader.css
+++ b/src/component/PageHeader.css
@@ -20,11 +20,20 @@
   color: white;
 }
 
-/* Make room for wrapped menus on tablets */
-@media (max-width: 992px) {
+.PageHeader .Hamburger span {
+  background: #ffffff;
+}
+
+/* Switch to compact header layout when drawer navigation takes over */
+@media (max-width: 940px) {
   .PageHeader {
-    flex-wrap: wrap;
-    row-gap: 8px;
+    flex-wrap: nowrap;
+    row-gap: 0;
+    justify-content: flex-start;
+  }
+
+  .PageHeader .MenuInline {
+    margin-left: auto;
   }
 }
 
@@ -62,6 +71,10 @@
 
 .MenuInline {
   display: flex;
+}
+
+.PageHeader .Hamburger {
+  margin-left: 0;
 }
 
 .MenuOptions {

--- a/src/component/PageHeader.js
+++ b/src/component/PageHeader.js
@@ -1,13 +1,61 @@
-import './PageHeader.css';
-import PageLogo from './PageLogo';
-import MenuOptions from './MenuOptions';
+import { useEffect, useRef } from "react";
+import "./PageHeader.css";
+import PageLogo from "./PageLogo";
+import MenuOptions from "./MenuOptions";
 
 const PageHeader = () => {
+    const toggleRef = useRef(null);
+
+    const closeMenu = () => {
+        if (toggleRef.current) toggleRef.current.checked = false;
+    };
+
+    useEffect(() => {
+        const el = toggleRef.current;
+        const onChange = () => {
+            const open = !!el?.checked;
+            document.documentElement.style.overflow = open ? "hidden" : "";
+        };
+
+        el?.addEventListener("change", onChange);
+        return () => {
+            document.documentElement.style.overflow = "";
+            el?.removeEventListener("change", onChange);
+        };
+    }, []);
+
+    const isExpanded = !!toggleRef.current?.checked;
 
     return (
         <header className='PageHeader'>
             <PageLogo />
-            <MenuOptions page={false} />
+
+            <nav className="MenuInline" aria-label="Primary">
+                <MenuOptions page={false} />
+            </nav>
+
+            <input
+                type="checkbox"
+                id="page-menu-toggle"
+                className="menu-toggle"
+                ref={toggleRef}
+                aria-label="Toggle navigation menu"
+            />
+
+            <label
+                htmlFor="page-menu-toggle"
+                className="Hamburger"
+                aria-controls="page-top-sheet"
+                aria-expanded={isExpanded}
+            >
+                <span></span><span></span><span></span>
+            </label>
+
+            <nav className="MenuPanel SideSheet" id="page-top-sheet" aria-label="Primary">
+                <MenuOptions page={false} onNavigate={closeMenu} />
+            </nav>
+
+            <label htmlFor="page-menu-toggle" className="MenuBackdrop" aria-hidden="true" />
         </header>
     );
 };

--- a/src/component/PageLogo.js
+++ b/src/component/PageLogo.js
@@ -1,16 +1,12 @@
-import Home from "../home/Home";
-import './PageLogo.css';
-import { Link } from 'react-router-dom';
+import "./PageLogo.css";
+import { Link } from "react-router-dom";
 
 const Logo = () => {
-
-    return (
-        <p className="PageLogo">
-            <Link to="/" element={<Home />}>
-                Verse by Verse
-            </Link>
-        </p>
-    );
+  return (
+    <p className="PageLogo">
+      <Link to="/">Verse by Verse</Link>
+    </p>
+  );
 };
 
 export default Logo;

--- a/src/home/homeBody/HomeBodyCard.js
+++ b/src/home/homeBody/HomeBodyCard.js
@@ -1,28 +1,24 @@
-import Community from '../../pages/Community/Community';
-import Study from '../../pages/Study/Study';
-import Home from '../Home';
-import './HomeBody.css';
-import { Link } from 'react-router-dom';
+import "./HomeBody.css";
+import { Link } from "react-router-dom";
 
 const HomeBodyCard = (props) => {
 
-    //About Page removed. Maybe add an about section to show how the web app should be used
-    //under the cards section and add a ref link to it to slide the page down to address it
     const cardType = props.type;
-    let link;
+    let link = null;
+
     switch (cardType) {
-        case 'about':
-            link = (<Link to='/' element={<Home/>}>Learn More</Link>);
+        case "about":
+            link = <Link to="/about">Learn More</Link>;
             break;
-        case 'read':
-            link = (<Link to='/read' element={<Study />}>Learn More</Link>);
+        case "read":
+        case "study":
+            link = <Link to="/study">Learn More</Link>;
             break;
-        case 'study':
-            link = (<Link to='/study' element={<Study />}>Learn More</Link>);
+        case "community":
+            link = <Link to="/community">Learn More</Link>;
             break;
-        case 'community':
-            link = (<Link to='/community' element={<Community />}>Learn More</Link>);
-            break;
+        default:
+            link = null;
     }
 
     return (

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,28 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 
+const RESIZE_OBSERVER_LOOP_ERRORS = [
+  "ResizeObserver loop completed with undelivered notifications.",
+  "ResizeObserver loop limit exceeded",
+];
+
+const isResizeObserverLoopError = (value) =>
+  RESIZE_OBSERVER_LOOP_ERRORS.some((message) =>
+    String(value || "").includes(message)
+  );
+
+window.addEventListener("error", (event) => {
+  if (isResizeObserverLoopError(event?.message)) {
+    event.stopImmediatePropagation();
+  }
+});
+
+window.addEventListener("unhandledrejection", (event) => {
+  if (isResizeObserverLoopError(event?.reason?.message || event?.reason)) {
+    event.preventDefault();
+  }
+});
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>

--- a/src/pages/Account/Account.css
+++ b/src/pages/Account/Account.css
@@ -337,16 +337,15 @@
 /* Change password panel (collapsed by default) */
 .password-change-panel {
   text-align: center;
-  max-height: 0;
-  overflow: hidden;
+  display: none;
   opacity: 0;
-  transition: max-height 0.3s ease, opacity 0.3s ease;
+  margin-top: 0;
+  overflow: hidden;
+  transition: opacity 0.2s ease;
 }
 
-/* When open, allow room for form + fade in */
 .password-change-panel--open {
-  max-height: 500px;
-  /* enough to fit 3 inputs + button */
+  display: block;
   opacity: 1;
   margin-top: 0.5rem;
 }


### PR DESCRIPTION
Restore and rebuild the About page with feature-based product documentation
Add detailed Feature View walkthrough pages for Study, Notes, and community flows
Improve Bible study formatting for multiline questions, structured shares, and share CTA state
Add a mobile-only unavailable screen with illustration and app-coming message
Update header behavior so hamburger navigation takes over at 940px while keeping the profile button visible
Fix inconsistent logo/navigation behavior and remove invalid router link patterns
Resolve Profile-page navigation runtime error by removing the password panel height animation that was causing layout thrash